### PR TITLE
Improve settings drag area and scrolling

### DIFF
--- a/files/script.js
+++ b/files/script.js
@@ -1,9 +1,30 @@
-let inventory = JSON.parse(localStorage.getItem("inventory")) || [];
+const storage = {
+  get(key, fallback = null) {
+    const raw = localStorage.getItem(key);
+    if (raw === null) return fallback;
+    try {
+      return JSON.parse(raw);
+    } catch (error) {
+      console.warn(`Failed to parse localStorage key "${key}". Resetting value.`, error);
+      localStorage.removeItem(key);
+      return fallback;
+    }
+  },
+  set(key, value) {
+    localStorage.setItem(key, JSON.stringify(value));
+  },
+};
+
+const byId = (id) => document.getElementById(id);
+const $all = (selector, root = document) => Array.from(root.querySelectorAll(selector));
+
+let inventory = storage.get("inventory", []);
 let currentPage = 1;
 const itemsPerPage = 10;
 let rollCount = parseInt(localStorage.getItem("rollCount")) || 0;
-let rollCount1 = parseInt(localStorage.getItem("rollCount")) || 0;
-let cooldownTime = 500;
+let rollCount1 = parseInt(localStorage.getItem("rollCount1")) || rollCount;
+const BASE_COOLDOWN_TIME = 500;
+let cooldownTime = BASE_COOLDOWN_TIME;
 let currentAudio = null;
 let isChangeEnabled = true;
 let autoRollInterval = null;
@@ -11,409 +32,502 @@ let audioVolume = 1;
 let isMuted = false;
 let previousVolume = audioVolume;
 let refreshTimeout;
+let hasScheduledLoad = false;
+let skipCutscene1K = true;
+let skipCutscene10K = true;
+let skipCutscene100K = true;
+let skipCutscene1M = true;
+let cooldownBuffActive = cooldownTime < BASE_COOLDOWN_TIME;
+
+const STOPPABLE_AUDIO_IDS = [
+  "suspenseAudio",
+  "expOpeningAudio",
+  "geezerSuspenceAudio",
+  "polarrSuspenceAudio",
+  "scareSuspenceAudio",
+  "scareSuspenceLofiAudio",
+  "waveAudio",
+  "scorchingAudio",
+  "beachAudio",
+  "tidalwaveAudio",
+  "gingerAudio",
+  "x1staAudio",
+  "lightAudio",
+  "astblaAudio",
+  "heartAudio",
+  "tuonAudio",
+  "blindAudio",
+  "iriAudio",
+  "aboAudio",
+  "shaAudio",
+  "lubjubAudio",
+  "demsoAudio",
+  "fircraAudio",
+  "plabreAudio",
+  "harvAudio",
+  "norstaAudio",
+  "sanclaAudio",
+  "silnigAudio",
+  "reidasAudio",
+  "frogarAudio",
+  "cancansymAudio",
+  "ginharAudio",
+  "jolbelAudio",
+  "eniAudio",
+  "darAudio",
+  "nighAudio",
+  "specAudio",
+  "twiligAudio",
+  "silAudio",
+  "isekaiAudio",
+  "equinoxAudio",
+  "emerAudio",
+  "samuraiAudio",
+  "contAudio",
+  "unstoppableAudio",
+  "gargantuaAudio",
+  "spectralAudio",
+  "starfallAudio",
+  "memAudio",
+  "oblAudio",
+  "phaAudio",
+  "frightAudio",
+  "unnamedAudio",
+  "overtureAudio",
+  "impeachedAudio",
+  "eonbreakAudio",
+  "celAudio",
+  "silcarAudio",
+  "gregAudio",
+  "mintllieAudio",
+  "geezerAudio",
+  "polarrAudio",
+  "oppAudio",
+  "serAudio",
+  "arcAudio",
+  "ethAudio",
+  "curAudio",
+  "hellAudio",
+  "wanspiAudio",
+  "mysAudio",
+  "voiAudio",
+  "endAudio",
+  "shadAudio",
+  "froAudio",
+  "forgAudio",
+  "curartAudio",
+  "ghoAudio",
+  "abysAudio",
+  "ethpulAudio",
+  "griAudio",
+  "celdawAudio",
+  "fatreAudio",
+  "fearAudio",
+  "hauAudio",
+  "foundsAudio",
+  "lostsAudio",
+  "hauntAudio",
+  "devilAudio",
+  "pumpkinAudio",
+  "h1diAudio",
+  "bigSuspenceAudio",
+  "hugeSuspenceAudio",
+  "expAudio",
+  "veilAudio",
+  "msfuAudio",
+  "blodAudio",
+  "orbAudio",
+  "astredAudio",
+  "crazeAudio",
+  "shenviiAudio",
+  "qbearAudio",
+  "estbunAudio",
+  "esteggAudio",
+  "isekailofiAudio"
+];
+
+const AUDIO_RESET_OVERRIDES = {
+  gargantuaAudio: 14.5,
+  eonbreakAudio: 2,
+  mintllieAudio: 37
+};
+
+const audioElementCache = new Map();
+const pendingAudioResetHandlers = new WeakMap();
+
+const LOADING_SEQUENCE = [
+  {
+    message: "Obtaining saves...",
+    action: () => {
+      inventory = storage.get("inventory", []);
+      rollCount = parseInt(localStorage.getItem("rollCount")) || 0;
+      rollCount1 = parseInt(localStorage.getItem("rollCount1")) || rollCount;
+    },
+  },
+  {
+    message: "Loading assets...",
+    action: () => {
+      musicLoad();
+    },
+  },
+  {
+    message: "Polishing titles...",
+    action: () => {
+      renderInventory();
+    },
+  },
+  {
+    message: "Cleaning the UI...",
+    action: () => {
+      loadToggledStates();
+      updateRollCount(0);
+      checkAchievements();
+      updateAchievementsList();
+      loadCutsceneSkip();
+    },
+  },
+];
+
+const LOADING_STEP_MIN_DURATION = 200;
+
+function wait(ms) {
+  return new Promise((resolve) => setTimeout(resolve, ms));
+}
+
+function nextFrame() {
+  return new Promise((resolve) => {
+    if (typeof requestAnimationFrame === "function") {
+      requestAnimationFrame(() => resolve());
+    } else {
+      setTimeout(resolve, 16);
+    }
+  });
+}
+
+async function runInitialLoadSequence(onProgress) {
+  const report = typeof onProgress === "function" ? onProgress : () => {};
+
+  for (const { message, action } of LOADING_SEQUENCE) {
+    report(message);
+    await nextFrame();
+
+    const start = typeof performance !== "undefined" && performance.now
+      ? performance.now()
+      : Date.now();
+
+    await action();
+
+    const end = typeof performance !== "undefined" && performance.now
+      ? performance.now()
+      : Date.now();
+
+    const elapsed = end - start;
+    if (elapsed < LOADING_STEP_MIN_DURATION) {
+      await wait(LOADING_STEP_MIN_DURATION - elapsed);
+    }
+  }
+
+  report("Ready!");
+  await wait(180);
+}
+
+const CUTSCENE_SKIP_SETTINGS = [
+  { key: "skipCutscene1K", labelId: "1KTxt", label: "Skip Decent Cutscenes" },
+  { key: "skipCutscene10K", labelId: "10KTxt", label: "Skip Grand Cutscenes" },
+  { key: "skipCutscene100K", labelId: "100KTxt", label: "Skip Mastery Cutscenes" },
+  { key: "skipCutscene1M", labelId: "1MTxt", label: "Skip Supreme Cutscenes" },
+];
+
+const CUTSCENE_STATE_SETTERS = {
+  skipCutscene1K: (value) => { skipCutscene1K = value; },
+  skipCutscene10K: (value) => { skipCutscene10K = value; },
+  skipCutscene100K: (value) => { skipCutscene100K = value; },
+  skipCutscene1M: (value) => { skipCutscene1M = value; },
+};
+
+const ACHIEVEMENTS = [
+  { name: "I think I like this", count: 100 },
+  { name: "This is getting serious", count: 1000 },
+  { name: "I'm the Roll Master", count: 5000 },
+  { name: "It's over 9000!!", count: 10000 },
+  { name: "When will you stop?", count: 25000 },
+  { name: "No Unnamed?", count: 30303 },
+  { name: "Beyond Luck", count: 50000 },
+  { name: "Rolling machine", count: 100000 },
+  { name: "Your PC must be burning", count: 250000 },
+  { name: "Half a million!1!!1", count: 500000 },
+  { name: "One, Two.. ..One Million!", count: 1000000 },
+  { name: "No H1di?", count: 10000000 },
+  { name: "Are you really doing this?", count: 25000000 },
+  { name: "You have no limits...", count: 50000000 },
+  { name: "WHAT HAVE YOU DONE", count: 100000000 },
+  { name: "AHHHHHHHHHHH", count: 1000000000 },
+  { name: "Just the beginning", timeCount: 0 },
+  { name: "This doesn't add up", timeCount: 3600 },
+  { name: "When does it end...", timeCount: 7200 },
+  { name: "I swear I'm not addicted...", timeCount: 36000 },
+  { name: "Grass? What's that?", timeCount: 86400 },
+  { name: "Unnamed's RNG biggest fan", timeCount: 172800 },
+  { name: "RNG is life!", timeCount: 604800 },
+  { name: "I. CAN'T. STOP", timeCount: 1209600 },
+  { name: "No Lifer", timeCount: 2629800 },
+  { name: "Are you okay?", timeCount: 5259600 },
+  { name: "You are a True No Lifer", timeCount: 15778800 },
+  { name: "No one's getting this legit", timeCount: 31557600 },
+  { name: "Happy Summer!", timeCount: 0 },
+];
+
+const COLLECTOR_ACHIEVEMENTS = [
+  { name: "Achievement Collector", count: 5 },
+  { name: "Achievement Hoarder", count: 10 },
+  { name: "Achievement Addict", count: 20 },
+  { name: "Achievement God", count: 33 },
+  { name: "T̶h̶e̶ ̶U̶l̶t̶i̶m̶a̶t̶e̶ ̶C̶o̶l̶l̶e̶c̶t̶o̶r̶", count: 50 },
+];
+
+const ACHIEVEMENT_GROUP_STYLES = [
+  { selector: ".achievement-item", unlocked: { backgroundColor: "blue" } },
+  { selector: ".achievement-itemT", unlocked: { backgroundColor: "green" } },
+  { selector: ".achievement-itemC", unlocked: { backgroundColor: "red" } },
+  { selector: ".achievement-itemE", unlocked: { backgroundColor: "yellow", color: "black" } },
+  { selector: ".achievement-itemSum", unlocked: { backgroundColor: "orange", color: "black" } },
+];
+
+const ACHIEVEMENT_TOAST_DURATION = 3400;
+const achievementToastQueue = [];
+let achievementToastContainer = null;
+let achievementToastActive = false;
+
+function ensureAchievementToastContainer() {
+  if (achievementToastContainer && document.body.contains(achievementToastContainer)) {
+    return achievementToastContainer;
+  }
+
+  achievementToastContainer = document.createElement("div");
+  achievementToastContainer.className = "achievement-toast-stack";
+  document.body.appendChild(achievementToastContainer);
+  return achievementToastContainer;
+}
+
+function processAchievementToastQueue() {
+  if (achievementToastActive || achievementToastQueue.length === 0) {
+    return;
+  }
+
+  achievementToastActive = true;
+  const name = achievementToastQueue.shift();
+  const container = ensureAchievementToastContainer();
+
+  const toast = document.createElement("div");
+  toast.className = "achievement-toast";
+  toast.innerHTML = `
+    <div class="achievement-toast__icon"><i class="fa-solid fa-trophy"></i></div>
+    <div class="achievement-toast__content">
+      <span class="achievement-toast__title">Achievement Unlocked</span>
+      <span class="achievement-toast__name">${name}</span>
+    </div>
+  `;
+  container.appendChild(toast);
+
+  requestAnimationFrame(() => {
+    toast.classList.add("show");
+  });
+
+  updateAchievementsList();
+
+  const removeToast = () => {
+    if (!toast.isConnected) {
+      return;
+    }
+
+    toast.classList.remove("show");
+    toast.classList.add("hide");
+
+    let finalized = false;
+    const finalize = () => {
+      if (finalized) {
+        return;
+      }
+      finalized = true;
+      toast.remove();
+      achievementToastActive = false;
+      updateAchievementsList();
+      processAchievementToastQueue();
+    };
+
+    toast.addEventListener("transitionend", finalize, { once: true });
+    setTimeout(finalize, 320);
+  };
+
+  setTimeout(removeToast, ACHIEVEMENT_TOAST_DURATION);
+}
+
+function getAudioElement(id) {
+  if (audioElementCache.has(id)) {
+    const cached = audioElementCache.get(id);
+    if (cached && document.contains(cached)) {
+      return cached;
+    }
+    audioElementCache.delete(id);
+  }
+
+  const element = document.getElementById(id) || window[id] || null;
+  if (element && element.preload === "none") {
+    element.preload = "auto";
+  }
+
+  audioElementCache.set(id, element);
+  return element;
+}
+
+function resetAudioState(audio, id) {
+  if (!audio) return;
+
+  const targetTime = AUDIO_RESET_OVERRIDES[id] ?? 0;
+  const assignTime = () => {
+    if (typeof audio.currentTime === "number" && audio.currentTime !== targetTime) {
+      try {
+        audio.currentTime = targetTime;
+      } catch (error) {
+        // Ignore errors that occur if metadata isn't available yet.
+      }
+    }
+  };
+
+  assignTime();
+
+  if (audio.readyState < 1 && !pendingAudioResetHandlers.has(audio)) {
+    const handler = () => {
+      pendingAudioResetHandlers.delete(audio);
+      audio.removeEventListener("loadedmetadata", handler);
+      assignTime();
+    };
+    pendingAudioResetHandlers.set(audio, handler);
+    audio.addEventListener("loadedmetadata", handler, { once: true });
+  }
+}
+
+function stopAllAudio() {
+  STOPPABLE_AUDIO_IDS.forEach((id) => {
+    const audio = getAudioElement(id);
+    if (!audio) {
+      return;
+    }
+
+    if (typeof audio.pause === "function") {
+      audio.pause();
+    }
+
+    resetAudioState(audio, id);
+  });
+}
 
 document.addEventListener("DOMContentLoaded", () => {
-  const rollButton = document.getElementById("rollButton");
-  const startButton = document.getElementById("startButton");
-  const loadingScreen = document.getElementById("loadingScreen");
-  const menuScreen = document.getElementById("menuScreen");
+  const rollButton = byId("rollButton");
+  const startButton = byId("startButton");
+  const loadingScreen = byId("loadingScreen");
+  const menuScreen = byId("menuScreen");
+  const loadingText = loadingScreen ? loadingScreen.querySelector(".loadTxt") : null;
 
-  rollButton.disabled = true;
+  if (rollButton) {
+    rollButton.disabled = true;
+  }
 
-  startButton.addEventListener("click", () => {
-    mainAudio.play();
-    menuScreen.style.display = "none";
-    loadingScreen.style.display = "flex";
-    load();
-    setTimeout(() => {
-      load();
-      loadContent();
-    }, 1000);
-    setTimeout(() => {
-      rollButton.disabled = false;
+  if (!startButton) {
+    return;
+  }
+
+  startButton.addEventListener("click", async () => {
+    if (startButton.disabled) {
+      return;
+    }
+
+    startButton.disabled = true;
+
+    try {
+      if (typeof mainAudio !== "undefined" && mainAudio) {
+        await mainAudio.play();
+      }
+    } catch (error) {
+      console.warn("Unable to start background audio immediately.", error);
+    }
+
+    if (menuScreen) {
+      menuScreen.style.display = "none";
+    }
+
+    if (loadingScreen) {
+      loadingScreen.style.display = "flex";
+    }
+
+    const updateMessage = (message) => {
+      if (loadingText) {
+        loadingText.textContent = message;
+      }
+    };
+
+    try {
+      await runInitialLoadSequence(updateMessage);
+    } catch (error) {
+      console.error("Failed to initialise game state.", error);
+      updateMessage("Load failed. Tap play to retry.");
+      if (loadingScreen) {
+        loadingScreen.style.display = "none";
+      }
+      if (menuScreen) {
+        menuScreen.style.display = "flex";
+      }
+      startButton.disabled = false;
+      return;
+    }
+
+    if (loadingScreen) {
       loadingScreen.style.display = "none";
-      formatRollCount();
-      loadToggledStates();
-      checkAchievements();
-      loadCutsceneSkip();
-      updateAchievementsList();
-    }, 2000);
+    }
+
+    if (rollButton) {
+      rollButton.disabled = false;
+    }
   });
 });
 
 function loadContent() {
-  const storedInventory = localStorage.getItem("inventory");
-  if (storedInventory) {
-    inventory = JSON.parse(storedInventory);
-  }
-  renderInventory();
-  musicLoad();
-  loadToggledStates();
-  updateRollCount();
-  checkAchievements();
-  updateAchievementsList();
-  loadCutsceneSkip();
-  document.getElementById("rollCountDisplay").innerText = formatRollCount(rollCount);
-  document.getElementById("rollCountDisplay1").innerText = rollCount1;
+  LOADING_SEQUENCE.forEach(({ action }) => action());
 }
 
 function load() {
-  document.addEventListener("DOMContentLoaded", (event) => {
-    const storedInventory = localStorage.getItem("inventory");
-    if (storedInventory) {
-      inventory = JSON.parse(storedInventory);
-    }
-    renderInventory();
-    musicLoad();
-    loadToggledStates();
-    updateRollCount();
-    formatRollCount();
-    checkAchievements();
-    updateAchievementsList();
-    loadCutsceneSkip();
-  });
+  if (document.readyState === "loading" && !hasScheduledLoad) {
+    hasScheduledLoad = true;
+    document.addEventListener("DOMContentLoaded", () => {
+      hasScheduledLoad = false;
+      loadContent();
+    }, { once: true });
+  }
 }
 
 function loadCutsceneSkip() {
-  skipCutscene1K = JSON.parse(localStorage.getItem('skipCutscene1K'));
-  if (skipCutscene1K === null) {
-    skipCutscene1K = true;
-    localStorage.setItem('skipCutscene1K', JSON.stringify(skipCutscene1K));
-  }
+  CUTSCENE_SKIP_SETTINGS.forEach(({ key, labelId, label }) => {
+    const storedValue = storage.get(key);
+    const resolvedValue = typeof storedValue === "boolean" ? storedValue : true;
 
-  skipCutscene10K = JSON.parse(localStorage.getItem('skipCutscene10K'));
-  if (skipCutscene10K === null) {
-    skipCutscene10K = true;
-    localStorage.setItem('skipCutscene10K', JSON.stringify(skipCutscene10K));
-  }
+    if (storedValue !== resolvedValue) {
+      storage.set(key, resolvedValue);
+    }
 
-  skipCutscene100K = JSON.parse(localStorage.getItem('skipCutscene100K'));
-  if (skipCutscene100K === null) {
-    skipCutscene100K = true;
-    localStorage.setItem('skipCutscene100K', JSON.stringify(skipCutscene100K));
-  }
+    const assignState = CUTSCENE_STATE_SETTERS[key];
+    if (assignState) {
+      assignState(resolvedValue);
+    }
 
-  skipCutscene1M = JSON.parse(localStorage.getItem('skipCutscene1M'));
-  if (skipCutscene1M === null) {
-    skipCutscene1M = true;
-    localStorage.setItem('skipCutscene1M', JSON.stringify(skipCutscene1M));
-  }
-  
-  document.getElementById("1KTxt").textContent = `Skip Decent Cutscenes ${skipCutscene1K ? "" : "On"}`;
-  document.getElementById("10KTxt").textContent = `Skip Grand Cutscenes ${skipCutscene10K ? "" : "On"}`;
-  document.getElementById("100KTxt").textContent = `Skip Mastery Cutscenes ${skipCutscene100K ? "" : "On"}`;
-  document.getElementById("1MTxt").textContent = `Skip Supreme Cutscenes ${skipCutscene1M ? "" : "On"}`;
+    const labelElement = byId(labelId);
+    if (labelElement) {
+      labelElement.textContent = `${label} ${resolvedValue ? "" : "On"}`;
+    }
+  });
 }
 
 function musicLoad() {
-  let suspenseAudio = document.getElementById("suspenseAudio");
-  let expOpeningAudio = document.getElementById("expOpeningAudio");
-  let geezerSuspenceAudio = document.getElementById("geezerSuspenceAudio");
-  let polarrSuspenceAudio = document.getElementById("polarrSuspenceAudio");
-  let scareSuspenceAudio = document.getElementById("scareSuspenceAudio");
-  let bigSuspenceAudio = document.getElementById("bigSuspenceAudio");
-  let waveAudio = document.getElementById("waveAudio");
-  let scorchingAudio = document.getElementById("scorchingAudio");
-  let beachAudio = document.getElementById("beachAudio");
-  let tidalwaveAudio = document.getElementById("tidalwaveAudio");
-  let gingerAudio = document.getElementById("gingerAudio");
-  let astblaAudio = document.getElementById("astblaAudio");
-  let iriAudio = document.getElementById("iriAudio");
-  let heartAudio = document.getElementById("heartAudio");
-  let tuonAudio = document.getElementById("tuonAudio");
-  let aboAudio = document.getElementById("aboAudio");
-  let lubjubAudio = document.getElementById("lubjubAudio");
-  let plabreAudio = document.getElementById("plabreAudio");
-  let isekaiAudio = document.getElementById("isekaiAudio");
-  let equinoxAudio = document.getElementById("equinoxAudio");
-  let fircraAudio = document.getElementById("fircraAudio");
-  let emerAudio = document.getElementById("emerAudio");
-  let shadAudio = document.getElementById("shadAudio");
-  let samuraiAudio = document.getElementById("samuraiAudio");
-  let contAudio = document.getElementById("contAudio");
-  let unstoppableAudio = document.getElementById("unstoppableAudio");
-  let gargantuaAudio = document.getElementById("gargantuaAudio");
-  let spectralAudio = document.getElementById("spectralAudio");
-  let starfallAudio = document.getElementById("starfallAudio");
-  let memAudio = document.getElementById("memAudio");
-  let oblAudio = document.getElementById("oblAudio");
-  let phaAudio = document.getElementById("phaAudio");
-  let frightAudio = document.getElementById("frightAudio");
-  let unnamedAudio = document.getElementById("unnamedAudio");
-  let overtureAudio = document.getElementById("overtureAudio");
-  let impeachedAudio = document.getElementById("impeachedAudio");
-  let eonbreakAudio = document.getElementById("eonbreakAudio");
-  let ethAudio = document.getElementById("ethAudio");
-  let celAudio = document.getElementById("celAudio");
-  let serAudio = document.getElementById("serAudio");
-  let arcAudio = document.getElementById("arcAudio");
-  let silcarAudio = document.getElementById("silcarAudio");
-  let gregAudio = document.getElementById("gregAudio");
-  let mintllieAudio = document.getElementById("mintllieAudio");
-  let geezerAudio = document.getElementById("geezerAudio");
-  let polarrAudio = document.getElementById("polarrAudio");
-  let oppAudio = document.getElementById("oppAudio");
-  let curAudio = document.getElementById("curAudio");
-  let wanspiAudio = document.getElementById("wanspiAudio");
-  let nighAudio = document.getElementById("nighAudio");
-  let mysAudio = document.getElementById("mysAudio");
-  let voiAudio = document.getElementById("voiAudio");
-  let endAudio = document.getElementById("endAudio");
-  let shaAudio = document.getElementById("shadAudio");
-  let twiligAudio = document.getElementById("twiligAudio");
-  let specAudio = document.getElementById("specAudio");
-  let silAudio = document.getElementById("silAudio");
-  let froAudio = document.getElementById("froAudio");
-  let forgAudio = document.getElementById("forgAudio");
-  let ghoAudio = document.getElementById("ghoAudio");
-  let curartAudio = document.getElementById("curartAudio");
-  let abysAudio = document.getElementById("abysAudio");
-  let hellAudio = document.getElementById("hellAudio");
-  let eniAudio = document.getElementById("eniAudio");
-  let griAudio = document.getElementById("griAudio");
-  let fatreAudio = document.getElementById("fatreAudio");
-  let fearAudio = document.getElementById("fearAudio");
-  let hauAudio = document.getElementById("hauAudio");
-  let celdawAudio = document.getElementById("celdawAudio");
-  let lostsAudio = document.getElementById("lostsAudio");
-  let hauntAudio = document.getElementById("hauntAudio");
-  let devilAudio = document.getElementById("devilAudio");
-  let darAudio = document.getElementById("darAudio");
-  let h1diAudio = document.getElementById("h1diAudio");
-  let pumpkinAudio = document.getElementById("pumpkinAudio");
-  let foundsAudio = document.getElementById("foundsAudio");
-  let ethpulAudio = document.getElementById("ethpulAudio");
-  let norstaAudio = document.getElementById("norstaAudio");
-  let sanclaAudio = document.getElementById("sanclaAudio");
-  let silnigAudio = document.getElementById("silnigAudio");
-  let reidasAudio = document.getElementById("reidasAudio");
-  let frogarAudio = document.getElementById("frogarAudio");
-  let cancansymAudio = document.getElementById("cancansymAudio");
-  let ginharAudio = document.getElementById("ginharAudio");
-  let jolbelAudio = document.getElementById("jolbelAudio");
-  let harvAudio = document.getElementById("harvAudio");
-  let expAudio = document.getElementById("expAudio");
-  let veilAudio = document.getElementById("veilAudio");
-  let demsoAudio = document.getElementById("demsoAudio");
-  let blindAudio = document.getElementById("blindAudio");
-  let msfuAudio = document.getElementById("msfuAudio");
-  let blodAudio = document.getElementById("blodAudio");
-  let orbAudio = document.getElementById("orbAudio");
-  let astredAudio = document.getElementById("astredAudio");
-  let crazeAudio = document.getElementById("crazeAudio");
-  let shenviiAudio = document.getElementById("shenviiAudio");
-  let qbearAudio = document.getElementById("qbearAudio");
-  let lightAudio = document.getElementById("lightAudio");
-  let x1staAudio = document.getElementById("x1staAudio");
-  let esteggAudio = document.getElementById("esteggAudio");
-  let estbunAudio = document.getElementById("estbunAudio");
-  let isekailofiAudio= document.getElementById("isekailofiAudio");
-
-  suspenseAudio.pause();
-  expOpeningAudio.pause();
-  geezerSuspenceAudio.pause();
-  polarrSuspenceAudio.pause();
-  scareSuspenceAudio.pause();
-  waveAudio.pause();
-  scorchingAudio.pause();
-  beachAudio.pause();
-  tidalwaveAudio.pause();
-  gingerAudio.pause();
-  x1staAudio.pause();
-  lightAudio.pause();
-  astblaAudio.pause();
-  heartAudio.pause();
-  tuonAudio.pause();
-  blindAudio.pause();
-  iriAudio.pause();
-  aboAudio.pause();
-  shaAudio.pause();
-  lubjubAudio.pause();
-  demsoAudio.pause();
-  fircraAudio.pause();
-  plabreAudio.pause();
-  harvAudio.pause();
-  norstaAudio.pause();
-  sanclaAudio.pause();
-  silnigAudio.pause();
-  reidasAudio.pause();
-  frogarAudio.pause();
-  cancansymAudio.pause();
-  ginharAudio.pause();
-  jolbelAudio.pause();
-  eniAudio.pause();
-  darAudio.pause();
-  nighAudio.pause();
-  specAudio.pause();
-  twiligAudio.pause();
-  silAudio.pause();
-  isekaiAudio.pause();
-  equinoxAudio.pause();
-  emerAudio.pause();
-  samuraiAudio.pause();
-  contAudio.pause();
-  unstoppableAudio.pause();
-  gargantuaAudio.pause();
-  spectralAudio.pause();
-  starfallAudio.pause();
-  memAudio.pause();
-  oblAudio.pause();
-  phaAudio.pause();
-  frightAudio.pause();
-  unnamedAudio.pause();
-  overtureAudio.pause();
-  impeachedAudio.pause();
-  eonbreakAudio.pause();
-  celAudio.pause();
-  silcarAudio.pause();
-  gregAudio.pause();
-  mintllieAudio.pause();
-  geezerAudio.pause();
-  polarrAudio.pause();
-  oppAudio.pause();
-  serAudio.pause();
-  arcAudio.pause();
-  ethAudio.pause();
-  curAudio.pause();
-  hellAudio.pause();
-  wanspiAudio.pause();
-  mysAudio.pause();
-  voiAudio.pause();
-  endAudio.pause();
-  shadAudio.pause();
-  froAudio.pause();
-  forgAudio.pause();
-  curartAudio.pause();
-  ghoAudio.pause();
-  abysAudio.pause();
-  ethpulAudio.pause();
-  griAudio.pause();
-  celdawAudio.pause();
-  fatreAudio.pause();
-  fearAudio.pause();
-  hauAudio.pause();
-  foundsAudio.pause();
-  lostsAudio.pause();
-  hauntAudio.pause();
-  devilAudio.pause();
-  pumpkinAudio.pause();
-  h1diAudio.pause();
-  bigSuspenceAudio.pause();
-  expAudio.pause();
-  veilAudio.pause();
-  msfuAudio.pause();
-  blodAudio.pause();
-  orbAudio.pause();
-  astredAudio.pause();
-  crazeAudio.pause();
-  shenviiAudio.pause();
-  qbearAudio.pause();
-  estbunAudio.pause();
-  esteggAudio.pause();
-  isekailofiAudio.pause();
-
-  suspenseAudio.currentTime = 0;
-  expOpeningAudio.currentTime = 0;
-  geezerSuspenceAudio.currentTime = 0;
-  polarrSuspenceAudio.currentTime = 0;
-  scareSuspenceAudio.currentTime = 0;
-  waveAudio.currentTime = 0;
-  scorchingAudio.currentTime = 0;
-  beachAudio.currentTime = 0;
-  tidalwaveAudio.currentTime = 0;
-  gingerAudio.currentTime = 0;
-  x1staAudio.currentTime = 0;
-  lightAudio.currentTime = 0;
-  tuonAudio.currentTime = 0;
-  astblaAudio.currentTime = 0;
-  heartAudio.currentTime = 0;
-  iriAudio.currentTime = 0;
-  blindAudio.currentTime = 0;
-  aboAudio.currentTime = 0;
-  shaAudio.currentTime = 0;
-  demsoAudio.currentTime = 0;
-  lubjubAudio.currentTime = 0;
-  fircraAudio.currentTime = 0;
-  plabreAudio.currentTime = 0;
-  harvAudio.currentTime = 0;
-  h1diAudio.currentTime = 0;
-  jolbelAudio.currentTime = 0;
-  ginharAudio.currentTime = 0;
-  cancansymAudio.currentTime = 0;
-  frogarAudio.currentTime = 0;
-  reidasAudio.currentTime = 0;
-  silnigAudio.currentTime = 0;
-  sanclaAudio.currentTime = 0;
-  norstaAudio.currentTime = 0;
-  nighAudio.currentTime = 0;
-  pumpkinAudio.currentTime = 0;
-  devilAudio.currentTime = 0;
-  hauntAudio.currentTime = 0;
-  lostsAudio.currentTime = 0;
-  foundsAudio.currentTime = 0;
-  hauAudio.currentTime = 0;
-  fatreAudio.currentTime = 0;
-  fearAudio.currentTime = 0;
-  celdawAudio.currentTime = 0;
-  griAudio.currentTime = 0;
-  eniAudio.currentTime = 0;
-  curartAudio.currentTime = 0;
-  ethpulAudio.currentTime = 0;
-  ghoAudio.currentTime = 0;
-  froAudio.currentTime = 0;
-  silAudio.currentTime = 0;
-  shadAudio.currentTime = 0;
-  specAudio.currentTime = 0;
-  twiligAudio.currentTime = 0;
-  isekaiAudio.currentTime = 0;
-  equinoxAudio.currentTime = 0;
-  emerAudio.currentTime = 0;
-  samuraiAudio.currentTime = 0;
-  contAudio.currentTime = 0;
-  unstoppableAudio.currentTime = 0;
-  gargantuaAudio.currentTime = 14.5;
-  spectralAudio.currentTime = 0;
-  starfallAudio.currentTime = 0;
-  memAudio.currentTime = 0;
-  oblAudio.currentTime = 0;
-  phaAudio.currentTime = 0;
-  frightAudio.currentTime = 0;
-  unnamedAudio.currentTime = 0;
-  overtureAudio.currentTime = 0;
-  impeachedAudio.currentTime = 0;
-  eonbreakAudio.currentTime = 2;
-  celAudio.currentTime = 0;
-  silcarAudio.currentTime = 0;
-  gregAudio.currentTime = 0;
-  mintllieAudio.currentTime = 37;
-  geezerAudio.currentTime = 0;
-  polarrAudio.currentTime = 0;
-  oppAudio.currentTime = 0;
-  serAudio.currentTime = 0;
-  arcAudio.currentTime = 0;
-  ethAudio.currentTime = 0;
-  curAudio.currentTime = 0;
-  hellAudio.currentTime = 0;
-  wanspiAudio.currentTime = 0;
-  mysAudio.currentTime = 0;
-  voiAudio.currentTime = 0;
-  endAudio.currentTime = 0;
-  forgAudio.currentTime = 0;
-  darAudio.currentTime = 0;
-  abysAudio.currentTime = 0;
-  bigSuspenceAudio.currentTime = 0;
-  expAudio.currentTime = 0;
-  veilAudio.currentTime = 0;
-  msfuAudio.currentTime = 0;
-  blodAudio.currentTime = 0;
-  orbAudio.currentTime = 0;
-  astredAudio.currentTime = 0;
-  crazeAudio.currentTime = 0;
-  shenviiAudio.currentTime = 0;
-  qbearAudio.currentTime = 0;
-  estbunAudio.currentTime = 0;
-  esteggAudio.currentTime = 0;
-  isekailofiAudio.currentTime = 0;
+  stopAllAudio();
 }
 
 function formatRollCount(count) {
@@ -431,171 +545,87 @@ function formatRollCount(count) {
   return count.toString();
 }
 
+function updateRollDisplays() {
+  const compactDisplay = byId("rollCountDisplay");
+  if (compactDisplay) {
+    compactDisplay.textContent = formatRollCount(rollCount);
+  }
+
+  const rawDisplay = byId("rollCountDisplay1");
+  if (rawDisplay) {
+    rawDisplay.textContent = rollCount1;
+  }
+}
+
 function updateRollCount(increment = 1) {
-  rollCount += increment;
-  rollCount1 += increment;
-  const display = document.getElementById('rollCountDisplay');
-  const display1 = document.getElementById('rollCountDisplay');
-  display.textContent = formatRollCount(rollCount);
-  display1.textContent = rollCount1;
+  if (increment) {
+    rollCount += increment;
+    rollCount1 += increment;
+  }
+  updateRollDisplays();
+}
+
+function persistUnlockedAchievements(unlocked) {
+  storage.set("unlockedAchievements", Array.from(unlocked));
+}
+
+function unlockAchievement(name, unlocked) {
+  if (unlocked.has(name)) {
+    return;
+  }
+  unlocked.add(name);
+  persistUnlockedAchievements(unlocked);
+  showAchievementPopup(name);
 }
 
 function checkAchievements() {
-  let achievements = [
-    // Rolls
-      { name: "I think I like this", count: 100 },
-      { name: "This is getting serious", count: 1000 },
-      { name: "I'm the Roll Master", count: 5000 },
-      { name: "It's over 9000!!", count: 10000 },
-      { name: "When will you stop?", count: 25000 },
-      { name: "No Unnamed?", count: 30303 },
-      { name: "Beyond Luck", count: 50000 },
-      { name: "Rolling machine", count: 100000 },
-      { name: "Your PC must be burning", count: 250000 },
-      { name: "Half a million!1!!1", count: 500000 },
-      { name: "One, Two.. ..One Million!", count: 1000000 },
-      { name: "No H1di?", count: 10000000 },
-      { name: "Are you really doing this?", count: 25000000 },
-      { name: "You have no limits...", count: 50000000 },
-      { name: "WHAT HAVE YOU DONE", count: 100000000 },
-      { name: "AHHHHHHHHHHH", count: 1000000000 },
+  const unlocked = new Set(storage.get("unlockedAchievements", []));
 
-      // Time
-      { name: "Just the beginning", timeCount: 0 },
-      { name: "This doesn't add up", timeCount: 3600 },
-      { name: "When does it end...", timeCount: 7200 },
-      { name: "I swear I'm not addicted...", timeCount: 36000 },
-      { name: "Grass? What's that?", timeCount: 86400 },
-      { name: "Unnamed's RNG biggest fan", timeCount: 172800 },
-      { name: "RNG is life!", timeCount: 604800 },
-      { name: "I. CAN'T. STOP", timeCount: 1209600 },
-      { name: "No Lifer", timeCount: 2629800 },
-      { name: "Are you okay?", timeCount: 5259600 },
-      { name: "You are a True No Lifer", timeCount: 15778800 },
-      { name: "No one's getting this legit", timeCount: 31557600 },
+  ACHIEVEMENTS.forEach((achievement) => {
+    if (achievement.count && rollCount >= achievement.count) {
+      unlockAchievement(achievement.name, unlocked);
+    }
 
-      // Event
-      { name: "Happy Summer!", timeCount: 0 },
-  ];
+    if (achievement.timeCount !== undefined && typeof playTime !== "undefined" && playTime >= achievement.timeCount) {
+      unlockAchievement(achievement.name, unlocked);
+    }
+  });
 
-  // Achievements collected
-  let collectorAchievements = [
-      { name: "Achievement Collector", count: 5 },
-      { name: "Achievement Hoarder", count: 10 },
-      { name: "Achievement Addict", count: 20 },
-      { name: "Achievement God", count: 33 },
-      { name: "T̶h̶e̶ ̶U̶l̶t̶i̶m̶a̶t̶e̶ ̶C̶o̶l̶l̶e̶c̶t̶o̶r̶", count: 50 }
-  ];
+  const unlockedCount = unlocked.size;
 
-  let unlockedAchievements = JSON.parse(localStorage.getItem("unlockedAchievements")) || [];
-
-  achievements.forEach(achievement => {
-      if (rollCount >= achievement.count && !unlockedAchievements.includes(achievement.name)) {
-          unlockedAchievements.push(achievement.name);
-          localStorage.setItem("unlockedAchievements", JSON.stringify(unlockedAchievements));
-          showAchievementPopup(achievement.name);
-      }
-      if (playTime >= achievement.timeCount && !unlockedAchievements.includes(achievement.name)) {
-        unlockedAchievements.push(achievement.name);
-        localStorage.setItem("unlockedAchievements", JSON.stringify(unlockedAchievements));
-        showAchievementPopup(achievement.name);
-      }
-
-      let unlockedCount = unlockedAchievements.length;
-      collectorAchievements.forEach(collector => {
-          if (unlockedCount >= collector.count && !unlockedAchievements.includes(collector.name)) {
-              unlockedAchievements.push(collector.name);
-              localStorage.setItem("unlockedAchievements", JSON.stringify(unlockedAchievements));
-              showAchievementPopup(collector.name);
-          }
-      });
+  COLLECTOR_ACHIEVEMENTS.forEach((collector) => {
+    if (unlockedCount >= collector.count) {
+      unlockAchievement(collector.name, unlocked);
+    }
   });
 }
 
 function showAchievementPopup(name) {
-  let popup = document.createElement("div");
-  popup.className = "achievement-popup";
-  popup.textContent = `Achievement Unlocked: ${name}`;
-  document.body.appendChild(popup);
-  
-  setTimeout(() => {
-      popup.classList.add("show");
-      updateAchievementsList();
-  }, 100);
-  
-  setTimeout(() => {
-      popup.classList.remove("show");
-      setTimeout(() => popup.remove(), 500);
-      updateAchievementsList();
-  }, 3000);
+  achievementToastQueue.push(name);
+  processAchievementToastQueue();
 }
 
 function updateAchievementsList() {
-  let unlockedAchievements = JSON.parse(localStorage.getItem("unlockedAchievements")) || [];
+  const unlocked = new Set(storage.get("unlockedAchievements", []));
 
-  let achievementItems = document.querySelectorAll(".achievement-item");
-  let achievementItemsT = document.querySelectorAll(".achievement-itemT");
-  let achievementItemsC = document.querySelectorAll(".achievement-itemC");
-  let achievementItemsE = document.querySelectorAll(".achievement-itemE");
-  let achievementItemsSum = document.querySelectorAll(".achievement-itemSum");
+  ACHIEVEMENT_GROUP_STYLES.forEach(({ selector, unlocked: unlockedStyles }) => {
+    $all(selector).forEach((item) => {
+      const achievementName = item.getAttribute("data-name");
+      const isUnlocked = achievementName && unlocked.has(achievementName);
 
-  achievementItems.forEach(item => {
-    const achievementName = item.getAttribute("data-name");
-
-    if (unlockedAchievements.includes(achievementName)) {
-      item.style.backgroundColor = "blue";
-    } else {
-      item.style.backgroundColor = "gray";
-    }
-  });
-
-  achievementItemsT.forEach(item => {
-    const achievementName = item.getAttribute("data-name");
-
-    if (unlockedAchievements.includes(achievementName)) {
-      item.style.backgroundColor = "green";
-    } else {
-      item.style.backgroundColor = "gray";
-    }
-  });
-
-  achievementItemsC.forEach(item => {
-    const achievementName = item.getAttribute("data-name");
-
-    if (unlockedAchievements.includes(achievementName)) {
-      item.style.backgroundColor = "red";
-    } else {
-      item.style.backgroundColor = "gray";
-    }
-  });
-
-  achievementItemsE.forEach(item => {
-    const achievementName = item.getAttribute("data-name");
-
-    if (unlockedAchievements.includes(achievementName)) {
-      item.style.backgroundColor = "yellow";
-      item.style.color = "black";
-    } else {
-      item.style.backgroundColor = "gray";
-    }
-  });
-
-  achievementItemsSum.forEach(item => {
-    const achievementName = item.getAttribute("data-name");
-
-    if (unlockedAchievements.includes(achievementName)) {
-      item.style.backgroundColor = "orange";
-      item.style.color = "black";
-    } else {
-      item.style.backgroundColor = "gray";
-    }
+      item.style.backgroundColor = isUnlocked ? unlockedStyles.backgroundColor : "gray";
+      item.style.color = isUnlocked && unlockedStyles.color ? unlockedStyles.color : "";
+    });
   });
 }
 
 document.addEventListener("DOMContentLoaded", updateAchievementsList);
 
 document.getElementById("rollButton").addEventListener("click", function () {
-  let rollButton = document.getElementById("rollButton");
+  const rollButton = byId("rollButton");
+  if (!rollButton) {
+    return;
+  }
 
   mainAudio.pause();
 
@@ -606,219 +636,21 @@ document.getElementById("rollButton").addEventListener("click", function () {
     rollCount++;
   }
 
-  suspenseAudio.pause();
-  geezerSuspenceAudio.pause();
-  polarrSuspenceAudio.pause();
-  scareSuspenceAudio.pause();
-  waveAudio.pause();
-  scorchingAudio.pause();
-  beachAudio.pause();
-  tidalwaveAudio.pause();
-  lightAudio.pause();
-  qbearAudio.pause();
-  shenviiAudio.pause();
-  astblaAudio.pause();
-  tuonAudio.pause();
-  iriAudio.pause();
-  aboAudio.pause();
-  shaAudio.pause();
-  lubjubAudio.pause();
-  plabreAudio.pause();
-  demsoAudio.pause();
-  harvAudio.pause();
-  norstaAudio.pause();
-  sanclaAudio.pause();
-  silnigAudio.pause();
-  reidasAudio.pause();
-  frogarAudio.pause();
-  cancansymAudio.pause();
-  ginharAudio.pause();
-  jolbelAudio.pause();
-  eniAudio.pause();
-  darAudio.pause();
-  nighAudio.pause();
-  specAudio.pause();
-  twiligAudio.pause();
-  silAudio.pause();
-  isekaiAudio.pause();
-  equinoxAudio.pause();
-  gingerAudio.pause();
-  emerAudio.pause();
-  samuraiAudio.pause();
-  contAudio.pause();
-  unstoppableAudio.pause();
-  gargantuaAudio.pause();
-  spectralAudio.pause();
-  starfallAudio.pause();
-  memAudio.pause();
-  oblAudio.pause();
-  phaAudio.pause();
-  frightAudio.pause();
-  unnamedAudio.pause();
-  overtureAudio.pause();
-  impeachedAudio.pause();
-  eonbreakAudio.pause();
-  celAudio.pause();
-  silcarAudio.pause();
-  gregAudio.pause();
-  mintllieAudio.pause();
-  geezerAudio.pause();
-  polarrAudio.pause();
-  oppAudio.pause();
-  serAudio.pause();
-  arcAudio.pause();
-  ethAudio.pause();
-  curAudio.pause();
-  hellAudio.pause();
-  wanspiAudio.pause();
-  mysAudio.pause();
-  voiAudio.pause();
-  endAudio.pause();
-  shadAudio.pause();
-  froAudio.pause();
-  forgAudio.pause();
-  curartAudio.pause();
-  ghoAudio.pause();
-  abysAudio.pause();
-  ethpulAudio.pause();
-  griAudio.pause();
-  celdawAudio.pause();
-  fatreAudio.pause();
-  fearAudio.pause();
-  hauAudio.pause();
-  foundsAudio.pause();
-  lostsAudio.pause();
-  hauntAudio.pause();
-  devilAudio.pause();
-  pumpkinAudio.pause();
-  h1diAudio.pause();
-  bigSuspenceAudio.pause();
-  expAudio.pause();
-  expOpeningAudio.pause();
-  veilAudio.pause();
-  fircraAudio.pause();
-  blindAudio.pause();
-  msfuAudio.pause();
-  blodAudio.pause();
-  orbAudio.pause();
-  heartAudio.pause();
-  astredAudio.pause();
-  crazeAudio.pause();
-  x1staAudio.pause();
-  esteggAudio.pause();
-  estbunAudio.pause();
-  isekailofiAudio.pause();
-
-  suspenseAudio.currentTime = 0;
-  geezerSuspenceAudio.currentTime = 0;
-  polarrSuspenceAudio.currentTime = 0;
-  scareSuspenceAudio.currentTime = 0;
-  waveAudio.currentTime = 0;
-  scorchingAudio.currentTime = 0;
-  beachAudio.currentTime = 0;
-  tidalwaveAudio.currentTime = 0;
-  lightAudio.currentTime = 0;
-  qbearAudio.currentTime = 0;
-  shenviiAudio.currentTime = 0;
-  heartAudio.currentTime = 0;
-  iriAudio.currentTime = 0;
-  aboAudio.currentTime = 0;
-  shaAudio.currentTime = 0;
-  lubjubAudio.currentTime = 0;
-  demsoAudio.currentTime = 0;
-  astblaAudio.currentTime = 0;
-  plabreAudio.currentTime = 0;
-  harvAudio.currentTime = 0;
-  h1diAudio.currentTime = 0;
-  jolbelAudio.currentTime = 0;
-  ginharAudio.currentTime = 0;
-  cancansymAudio.currentTime = 0;
-  frogarAudio.currentTime = 0;
-  reidasAudio.currentTime = 0;
-  silnigAudio.currentTime = 0;
-  sanclaAudio.currentTime = 0;
-  norstaAudio.currentTime = 0;
-  nighAudio.currentTime = 0;
-  pumpkinAudio.currentTime = 0;
-  tuonAudio.currentTime = 0;
-  devilAudio.currentTime = 0;
-  hauntAudio.currentTime = 0;
-  lostsAudio.currentTime = 0;
-  foundsAudio.currentTime = 0;
-  hauAudio.currentTime = 0;
-  fatreAudio.currentTime = 0;
-  fearAudio.currentTime = 0;
-  celdawAudio.currentTime = 0;
-  griAudio.currentTime = 0;
-  eniAudio.currentTime = 0;
-  curartAudio.currentTime = 0;
-  ethpulAudio.currentTime = 0;
-  ghoAudio.currentTime = 0;
-  froAudio.currentTime = 0;
-  silAudio.currentTime = 0;
-  shadAudio.currentTime = 0;
-  specAudio.currentTime = 0;
-  twiligAudio.currentTime = 0;
-  isekaiAudio.currentTime = 0;
-  equinoxAudio.currentTime = 0;
-  gingerAudio.currentTime = 0;
-  emerAudio.currentTime = 0;
-  samuraiAudio.currentTime = 0;
-  contAudio.currentTime = 0;
-  unstoppableAudio.currentTime = 0;
-  gargantuaAudio.currentTime = 14.5;
-  spectralAudio.currentTime = 0;
-  starfallAudio.currentTime = 0;
-  memAudio.currentTime = 0;
-  oblAudio.currentTime = 0;
-  phaAudio.currentTime = 0;
-  frightAudio.currentTime = 0;
-  unnamedAudio.currentTime = 0;
-  overtureAudio.currentTime = 0;
-  impeachedAudio.currentTime = 0;
-  eonbreakAudio.currentTime = 2;
-  celAudio.currentTime = 0;
-  silcarAudio.currentTime = 0;
-  gregAudio.currentTime = 0;
-  mintllieAudio.currentTime = 37;
-  geezerAudio.currentTime = 0;
-  polarrAudio.currentTime = 0;
-  oppAudio.currentTime = 0;
-  serAudio.currentTime = 0;
-  arcAudio.currentTime = 0;
-  ethAudio.currentTime = 0;
-  curAudio.currentTime = 0;
-  hellAudio.currentTime = 0;
-  wanspiAudio.currentTime = 0;
-  mysAudio.currentTime = 0;
-  voiAudio.currentTime = 0;
-  endAudio.currentTime = 0;
-  forgAudio.currentTime = 0;
-  darAudio.currentTime = 0;
-  abysAudio.currentTime = 0;
-  bigSuspenceAudio.currentTime = 0;
-  expAudio.currentTime = 0;
-  expOpeningAudio.currentTime = 0;
-  veilAudio.currentTime = 0;
-  fircraAudio.currentTime = 0;
-  blindAudio.currentTime = 0;
-  msfuAudio.currentTime = 0;
-  blodAudio.currentTime = 0;
-  orbAudio.currentTime = 0;
-  astredAudio.currentTime = 0;
-  crazeAudio.currentTime = 0;
-  x1staAudio.currenttime = 0;
-  esteggAudio.currenttime = 0;
-  estbunAudio.currenttime = 0;
-  isekailofiAudio.currenttime = 0;
+  stopAllAudio();
 
   let rarity = rollRarity();
   let title = selectTitle(rarity);
 
   rollButton.disabled = true;
 
-  document.getElementById("rollCountDisplay").innerText = formatRollCount(rollCount);
-  document.getElementById("rollCountDisplay1").innerText = rollCount1;
+  const rollCountDisplay = byId("rollCountDisplay");
+  if (rollCountDisplay) {
+    rollCountDisplay.textContent = formatRollCount(rollCount);
+  }
+  const rollCountDisplayRaw = byId("rollCountDisplay1");
+  if (rollCountDisplayRaw) {
+    rollCountDisplayRaw.textContent = rollCount1;
+  }
 
   if (
     rarity.type === "Cursed Mirage [1 in 11,111]" ||
@@ -910,9 +742,14 @@ document.getElementById("rollButton").addEventListener("click", function () {
     rarity.type === "Beach [1 in 12,555]" ||
     rarity.type === "Tidal Wave [1 in 25,500]"
   ) {
-    document.getElementById("result").innerText = "";
+    const resultContainer = byId("result");
+    if (resultContainer) {
+      resultContainer.textContent = "";
+    }
     const titleCont = document.querySelector(".container");
-
+    if (!titleCont) {
+      return;
+    }
     titleCont.style.visibility = "hidden";
 
     if (rarity.type === "Fright [1 in 1,075]") {
@@ -8868,12 +8705,6 @@ document.getElementById("rollButton").addEventListener("click", function () {
   load();
 });
 
-let skipCutscene1K = true;
-let skipCutscene10K = true;
-let skipCutscene100K = true;
-let skipCutscene1M = true;
-
-
 const toggleCutscene1KBtn = document.getElementById("toggleCutscene1K");
 const toggleCutscene1KTxt = document.getElementById("1KTxt");
 toggleCutscene1KBtn.addEventListener("click", function () {
@@ -10788,86 +10619,45 @@ function startAnimationBlackHole() {
   });
 }
 
-function createCooldownButton() {
-  if (document.getElementById("cooldownButton")) {
-    return;
-  }
+const COOLDOWN_BUTTON_CONFIGS = [
+  { id: "cooldownButton", reduceTo: 350, effectSeconds: 90, resetDelay: 90000, spawnDelay: 120000 },
+  { id: "cooldownButton1", reduceTo: 200, effectSeconds: 60, resetDelay: 60000, spawnDelay: 300000 },
+  { id: "cooldownButton2", reduceTo: 75, effectSeconds: 30, resetDelay: 30000, spawnDelay: 600000 },
+];
 
-  const button = document.createElement("button");
-  button.innerText = "Reduce Cooldown";
-  button.id = "cooldownButton";
-  button.style.position = "absolute";
+const cooldownSpawnTimers = new Map();
 
-  const randomX = Math.floor(Math.random() * (window.innerWidth - 100));
-  const randomY = Math.floor(Math.random() * (window.innerHeight - 50));
-  button.style.left = `${randomX}px`;
-  button.style.top = `${randomY}px`;
-
-  button.addEventListener("click", () => {
-    cooldownTime = 350;
-
-    showCooldownEffect(90);
-
-    button.innerText = "Cooldown Reduced!";
-    setTimeout(() => {
-      document.body.removeChild(button);
-    }, 1000);
-
-    setTimeout(() => {
-      cooldownTime = 500;
-      console.log("Cooldown reset to 500ms");
-    }, 90000);
-
-    scheduleButtonAppearance();
-  });
-
-  document.body.appendChild(button);
+function getActiveCooldownButton() {
+  return document.querySelector("#cooldownButton, #cooldownButton1, #cooldownButton2");
 }
 
-function createCooldownButton1() {
-  if (document.getElementById("cooldownButton")) {
-    return;
+function scheduleCooldownButton(config, delay = config.spawnDelay) {
+  const existingTimer = cooldownSpawnTimers.get(config.id);
+  if (existingTimer) {
+    clearTimeout(existingTimer);
   }
 
-  const button = document.createElement("button");
-  button.innerText = "Reduce Cooldown";
-  button.id = "cooldownButton1";
-  button.style.position = "absolute";
+  const timer = setTimeout(() => {
+    if (cooldownBuffActive || cooldownTime < BASE_COOLDOWN_TIME || getActiveCooldownButton()) {
+      scheduleCooldownButton(config, 10000);
+      return;
+    }
 
-  const randomX = Math.floor(Math.random() * (window.innerWidth - 100));
-  const randomY = Math.floor(Math.random() * (window.innerHeight - 50));
-  button.style.left = `${randomX}px`;
-  button.style.top = `${randomY}px`;
+    spawnCooldownButton(config);
+  }, delay);
 
-  button.addEventListener("click", () => {
-    cooldownTime = 200;
-
-    showCooldownEffect(60);
-
-    button.innerText = "Cooldown Reduced!";
-    setTimeout(() => {
-      document.body.removeChild(button);
-    }, 1000);
-
-    setTimeout(() => {
-      cooldownTime = 500;
-      console.log("Cooldown reset to 500ms");
-    }, 60000);
-
-    scheduleButtonAppearance();
-  });
-
-  document.body.appendChild(button);
+  cooldownSpawnTimers.set(config.id, timer);
 }
 
-function createCooldownButton2() {
-  if (document.getElementById("cooldownButton")) {
+function spawnCooldownButton(config) {
+  if (cooldownBuffActive || cooldownTime < BASE_COOLDOWN_TIME || getActiveCooldownButton()) {
+    scheduleCooldownButton(config, 10000);
     return;
   }
 
   const button = document.createElement("button");
   button.innerText = "Reduce Cooldown";
-  button.id = "cooldownButton2";
+  button.id = config.id;
   button.style.position = "absolute";
 
   const randomX = Math.floor(Math.random() * (window.innerWidth - 100));
@@ -10876,27 +10666,40 @@ function createCooldownButton2() {
   button.style.top = `${randomY}px`;
 
   button.addEventListener("click", () => {
-    cooldownTime = 75;
+    if (cooldownBuffActive) {
+      return;
+    }
 
-    showCooldownEffect(30);
+    cooldownBuffActive = true;
+    cooldownTime = config.reduceTo;
+
+    showCooldownEffect(config.effectSeconds);
 
     button.innerText = "Cooldown Reduced!";
+    button.disabled = true;
+
     setTimeout(() => {
-      document.body.removeChild(button);
+      if (button.isConnected) {
+        document.body.removeChild(button);
+      }
     }, 1000);
 
     setTimeout(() => {
-      cooldownTime = 500;
-      console.log("Cooldown reset to 500ms");
-    }, 30000);
-
-    scheduleButtonAppearance();
+      cooldownTime = BASE_COOLDOWN_TIME;
+      cooldownBuffActive = false;
+      scheduleAllCooldownButtons();
+    }, config.resetDelay);
   });
 
   document.body.appendChild(button);
 }
 
 function showCooldownEffect(duration) {
+  const existingDisplay = document.getElementById("countdownDisplay");
+  if (existingDisplay) {
+    existingDisplay.remove();
+  }
+
   const countdownDisplay = document.createElement("div");
   countdownDisplay.id = "countdownDisplay";
   countdownDisplay.style.position = "fixed";
@@ -10908,81 +10711,93 @@ function showCooldownEffect(duration) {
   countdownDisplay.style.borderRadius = "5px";
   countdownDisplay.style.zIndex = "100000";
 
+  countdownDisplay.innerText = `Roll-Cooldown Effect: ${duration}s`;
   document.body.appendChild(countdownDisplay);
 
-  let timeLeft = duration;
+  let timeLeft = duration - 1;
   const interval = setInterval(() => {
-    if (timeLeft <= 0) {
+    if (timeLeft < 0) {
       clearInterval(interval);
-      countdownDisplay.innerText = "";
-      document.body.removeChild(countdownDisplay);
-    } else {
-      countdownDisplay.innerText = `Roll-Cooldown Effect: ${timeLeft}s`;
+      if (countdownDisplay.isConnected) {
+        document.body.removeChild(countdownDisplay);
+      }
+      return;
     }
+
+    countdownDisplay.innerText = `Roll-Cooldown Effect: ${timeLeft}s`;
     timeLeft--;
   }, 1000);
 }
 
-function scheduleButtonAppearance() {
-
-  setTimeout(() => {
-    createCooldownButton();
-  }, 120000);
-
-  setTimeout(() => {
-    createCooldownButton1();
-  }, 300000);
-
-  setTimeout(() => {
-    createCooldownButton2();
-  }, 600000);
+function scheduleAllCooldownButtons() {
+  COOLDOWN_BUTTON_CONFIGS.forEach((config) => {
+    scheduleCooldownButton(config);
+  });
 }
 
-scheduleButtonAppearance();
+scheduleAllCooldownButtons();
 
 document.addEventListener("DOMContentLoaded", () => {
   const settingsMenu = document.getElementById("settingsMenu");
-  const header = settingsMenu.querySelector("h3");
+  const settingsHeader = settingsMenu?.querySelector(".settings-header");
   const headerStats = statsMenu.querySelector("h3");
-  let isDragging = false;
+  let isDraggingSettings = false;
   let isDraggingStats = false;
-  let offsetX, offsetY;
-  let offsetXStyle, offsetYStyle;
+  let offsetX = 0;
+  let offsetY = 0;
+  let offsetXStyle = 0;
+  let offsetYStyle = 0;
 
-  header.addEventListener("mousedown", (e) => {
-      isDragging = true;
-      offsetX = e.clientX - settingsMenu.offsetLeft;
-      offsetY = e.clientY - settingsMenu.offsetTop;
-      header.style.cursor = "grabbing";
-  });
+  if (settingsHeader) {
+    settingsHeader.addEventListener("mousedown", (event) => {
+      if (event.button !== 0 || event.target.closest(".settings-close-btn")) {
+        return;
+      }
 
-  headerStats.addEventListener("mousedown", (a) => {
-    isDraggingStats = true;
-    offsetXStyle = a.clientX - statsMenu.offsetLeft;
-    offsetYStyle = a.clientY - statsMenu.offsetTop;
-    headerStats.style.cursor = "grabbing";
-  })
+      const rect = settingsMenu.getBoundingClientRect();
+      settingsMenu.style.left = `${rect.left}px`;
+      settingsMenu.style.top = `${rect.top}px`;
+      settingsMenu.style.transform = "none";
 
-  document.addEventListener("mousemove", (e) => {
-      if (!isDragging) return;
-      settingsMenu.style.left = e.clientX - offsetX + "px";
-      settingsMenu.style.top = e.clientY - offsetY + "px";
-  });
+      offsetX = event.clientX - rect.left;
+      offsetY = event.clientY - rect.top;
+      isDraggingSettings = true;
+      settingsHeader.classList.add("is-dragging");
+      event.preventDefault();
+    });
+  }
 
-  document.addEventListener("mousemove", (a) => {
-      if (!isDraggingStats) return;
-      statsMenu.style.left = a.clientX - offsetXStyle + "px";
-      statsMenu.style.top = a.clientY - offsetYStyle + "px";
+  if (headerStats) {
+    headerStats.addEventListener("mousedown", (event) => {
+      isDraggingStats = true;
+      offsetXStyle = event.clientX - statsMenu.offsetLeft;
+      offsetYStyle = event.clientY - statsMenu.offsetTop;
+      headerStats.style.cursor = "grabbing";
+    });
+  }
+
+  document.addEventListener("mousemove", (event) => {
+    if (isDraggingSettings) {
+      settingsMenu.style.left = `${event.clientX - offsetX}px`;
+      settingsMenu.style.top = `${event.clientY - offsetY}px`;
+    }
+
+    if (isDraggingStats) {
+      statsMenu.style.left = `${event.clientX - offsetXStyle}px`;
+      statsMenu.style.top = `${event.clientY - offsetYStyle}px`;
+    }
   });
 
   document.addEventListener("mouseup", () => {
-      isDragging = false;
-      header.style.cursor = "grab";
-  });
+    if (isDraggingSettings) {
+      isDraggingSettings = false;
+      settingsHeader?.classList.remove("is-dragging");
+    }
 
-  document.addEventListener("mouseup", () => {
+    if (isDraggingStats) {
       isDraggingStats = false;
       headerStats.style.cursor = "grab";
+    }
   });
 });
 
@@ -10996,6 +10811,7 @@ const closeStats = document.getElementById("closeStats");
 const settingsMenu = document.getElementById("settingsMenu");
 const closeSettings = document.getElementById("closeSettings");
 const audioSlider = document.getElementById("audioSlider");
+const audioSliderValueLabel = document.getElementById("audioSliderValue");
 const resetDataButton = document.getElementById("resetDataButton");
 const autoRollButton = document.getElementById("autoRollButton");
 const rollButton = document.getElementById("rollButton");
@@ -11035,20 +10851,22 @@ if (savedVolume !== null) {
 } else {
   updateAudioElements(audioVolume);
 }
+setSliderMutedState(audioVolume === 0);
+updateAudioSliderUi();
 
 audioSlider.addEventListener("input", () => {
   audioVolume = parseFloat(audioSlider.value);
   if (audioVolume === 0) {
     isMuted = true;
-    setThumbColor(true);
+    setSliderMutedState(true);
   } else {
     isMuted = false;
-    setThumbColor(false);
     previousVolume = audioVolume;
+    setSliderMutedState(false);
   }
-  console.log(`Audio volume set to: ${audioVolume}`);
   localStorage.setItem("audioVolume", audioVolume);
   updateAudioElements(audioVolume);
+  updateAudioSliderUi();
 });
 
 muteButton.addEventListener("click", () => {
@@ -11063,9 +10881,9 @@ muteButton.addEventListener("click", () => {
 
   audioSlider.value = audioVolume;
   localStorage.setItem("audioVolume", audioVolume);
-  console.log(`Mute toggled. Audio volume is now: ${audioVolume}`);
   updateAudioElements(audioVolume);
-  setThumbColor(isMuted);
+  setSliderMutedState(isMuted);
+  updateAudioSliderUi();
 });
 
 function updateAudioElements(volume) {
@@ -11073,12 +10891,39 @@ function updateAudioElements(volume) {
   audioElements.forEach((audio) => (audio.volume = volume));
 }
 
-function setThumbColor(muted) {
-  if (muted) {
-    audioSlider.classList.add("muted");
-  } else {
-    audioSlider.classList.remove("muted");
+function setSliderMutedState(muted) {
+  if (!audioSlider) {
+    return;
   }
+
+  audioSlider.classList.toggle("muted", Boolean(muted));
+}
+
+function updateAudioSliderUi() {
+  if (!audioSlider) {
+    return;
+  }
+
+  const value = Math.max(0, Math.min(1, parseFloat(audioSlider.value) || 0));
+  const percentage = Math.round(value * 100);
+  if (audioSliderValueLabel) {
+    audioSliderValueLabel.textContent = `${percentage}%`;
+  }
+
+  const startColor = { r: 96, g: 0, b: 126 };
+  const endColor = { r: 255, g: 165, b: 0 };
+  const r = Math.round(startColor.r + (endColor.r - startColor.r) * value);
+  const g = Math.round(startColor.g + (endColor.g - startColor.g) * value);
+  const b = Math.round(startColor.b + (endColor.b - startColor.b) * value);
+  const thumbColor = `rgb(${r}, ${g}, ${b})`;
+
+  audioSlider.style.setProperty("--thumb-color", thumbColor);
+
+  const trackColor = audioSlider.classList.contains("muted")
+    ? "rgba(128, 96, 186, 0.75)"
+    : thumbColor;
+
+  audioSlider.style.background = `linear-gradient(90deg, ${trackColor} ${percentage}%, rgba(255, 255, 255, 0.12) ${percentage}%)`;
 }
 
 resetDataButton.addEventListener("click", () => {
@@ -11130,24 +10975,7 @@ function stopAutoRoll() {
   localStorage.setItem("autoRollEnabled", "false");
 }
 
-const slider = document.getElementById("audioSlider");
-
-slider.addEventListener("input", function () {
-  const value = slider.value;
-
-  const startColor = { r: 96, g: 0, b: 126 };
-  const endColor = { r: 255, g: 165, b: 0 };
-
-  const r = Math.round(startColor.r + (endColor.r - startColor.r) * value);
-  const g = Math.round(startColor.g + (endColor.g - startColor.g) * value);
-  const b = Math.round(startColor.b + (endColor.b - startColor.b) * value);
-
-  const thumbColor = `rgb(${r}, ${g}, ${b})`;
-
-  slider.style.setProperty("--thumb-color", thumbColor);
-});
-
-slider.dispatchEvent(new Event("input"));
+updateAudioSliderUi();
 
 const heartContainer = document.createElement('div');
 document.body.appendChild(heartContainer);

--- a/files/style.css
+++ b/files/style.css
@@ -1012,97 +1012,244 @@ body {
     top: 50%;
     left: 50%;
     transform: translate(-50%, -50%);
-    width: 600px;
-    padding: 20px;
-    background: url(backgrounds/rng_master.png);
-    border-radius: 10px;
-    border-style: groove;
-    box-shadow: 0 4px 10px rgba(0, 0, 0, 0.5);
+    width: min(640px, calc(100vw - 32px));
+    max-height: min(80vh, 620px);
+    padding: 0;
+    background:
+        linear-gradient(160deg, rgba(28,34,54,0.88), rgba(12,18,32,0.95)),
+        url(backgrounds/rng_master.png);
+    background-size: cover;
+    border-radius: 18px;
+    border: 1px solid rgba(120, 164, 255, 0.25);
+    box-shadow: 0 24px 60px rgba(0, 0, 0, 0.55);
     z-index: 10000000;
-    color: white;
-    font-family: 'Arial', sans-serif;
+    color: #f1f5ff;
+    overflow: hidden;
+}
+
+.settings-panel {
+    display: flex;
+    flex-direction: column;
+    height: 100%;
+    min-height: 0;
+}
+
+.settings-header {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    gap: 16px;
+    padding: 18px 22px 14px 22px;
+    border-bottom: 1px solid rgba(120, 164, 255, 0.16);
+    background: rgba(10, 14, 26, 0.65);
+    backdrop-filter: blur(12px);
+    cursor: grab;
+    user-select: none;
+}
+
+.settings-header .dragTxt {
+    opacity: 0.85;
+    font-size: 1.25rem;
+    font-weight: 600;
+    padding: 0;
+}
+
+.settings-close-btn {
+    background: rgba(255, 255, 255, 0.08);
+    color: #f1f5ff;
+    border-radius: 999px;
+    padding: 8px 16px;
+    font-size: 0.9rem;
+    font-weight: 600;
+    transition: background 0.2s ease, color 0.2s ease;
+}
+
+.settings-close-btn:hover {
+    background: rgba(255, 255, 255, 0.14);
+    color: #fff;
+}
+
+.settings-body {
+    flex: 1;
+    overflow-y: auto;
+    padding: 20px 22px 24px 22px;
+    display: flex;
+    flex-direction: column;
+    gap: 18px;
+    min-height: 0;
+}
+
+.settings-header.is-dragging {
+    cursor: grabbing;
+}
+
+.settings-section {
+    background: rgba(15, 22, 38, 0.78);
+    border: 1px solid rgba(120, 164, 255, 0.14);
+    border-radius: 14px;
+    padding: 16px 18px;
+    display: flex;
+    flex-direction: column;
+    gap: 14px;
+    box-shadow: inset 0 0 0 1px rgba(255,255,255,0.02);
+}
+
+.settings-section__title {
+    margin: 0;
+    font-size: 0.95rem;
+    letter-spacing: 0.08em;
+    text-transform: uppercase;
+    color: color-mix(in srgb, #c8d8ff 82%, #fff 18%);
+}
+
+.settings-grid {
+    display: grid;
+    gap: 12px;
+    grid-template-columns: repeat(auto-fit, minmax(160px, 1fr));
+}
+
+.settings-btn,
+.settings-close-btn {
+    border: 1px solid rgba(255, 255, 255, 0.12);
+    border-radius: 12px;
+    background: rgba(40, 62, 110, 0.55);
+    color: #f4f7ff;
+    padding: 10px 14px;
+    font-size: 0.95rem;
+    font-weight: 600;
     text-align: center;
+    transition: transform 0.2s ease, background 0.2s ease, border-color 0.2s ease;
 }
 
-#settingsMenu .rollsCount1 {
-    padding: 15px;
-    border-radius: 10px;
+.settings-btn:hover,
+.settings-close-btn:hover {
+    transform: translateY(-1px);
+    background: rgba(76, 104, 163, 0.75);
+    border-color: rgba(167, 200, 255, 0.4);
 }
 
-#settingsMenu h2 {
-    font-size: 1.5rem;
-    margin-bottom: 20px;
-    color: #ffa500;
+.settings-btn:active,
+.settings-close-btn:active {
+    transform: translateY(0);
+}
+
+.settings-btn--danger {
+    background: rgba(128, 36, 44, 0.65);
+    border-color: rgba(255, 120, 130, 0.4);
+}
+
+.settings-btn--danger:hover {
+    background: rgba(170, 50, 62, 0.72);
+    border-color: rgba(255, 158, 168, 0.55);
+}
+
+.settings-btn--ghost {
+    background: rgba(18, 26, 46, 0.55);
+    border-color: rgba(130, 180, 255, 0.2);
+}
+
+.settings-chip-group {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 10px;
+}
+
+.settings-chip-group > button {
+    border-radius: 999px;
+    padding: 8px 14px;
+    font-size: 0.85rem;
+    background: rgba(36, 48, 78, 0.7);
+    border: 1px solid rgba(130, 176, 255, 0.28);
+}
+
+.settings-chip-group > button:hover {
+    background: rgba(60, 90, 146, 0.8);
+}
+
+.settings-audio {
+    display: flex;
+    flex-direction: column;
+    gap: 12px;
+}
+
+.settings-audio__label {
+    font-size: 0.9rem;
+    color: rgba(222, 233, 255, 0.85);
+}
+
+.settings-audio__controls {
+    display: flex;
+    align-items: center;
+    flex-wrap: wrap;
+    gap: 12px;
+}
+
+.settings-audio__slider {
+    flex: 1;
+    display: flex;
+    align-items: center;
+    gap: 12px;
+    min-width: 220px;
+}
+
+.settings-audio__value {
+    font-variant-numeric: tabular-nums;
+    font-size: 0.9rem;
+    color: rgba(240, 247, 255, 0.82);
+    min-width: 3.5ch;
+    text-align: right;
 }
 
 #audioSlider {
     width: 100%;
-    -webkit-appearance: none;
     appearance: none;
-    background: linear-gradient(to right, #60007e 0%, #ffa500 100%);
     height: 10px;
-    border-radius: 10px;
-    outline: none;
+    border-radius: 999px;
     cursor: pointer;
-    flex: 1;
+    outline: none;
+    background: linear-gradient(90deg, rgba(255, 187, 120, 0.85) 100%, rgba(255, 255, 255, 0.12) 0%);
+    transition: background 0.2s ease;
 }
 
 #audioSlider::-webkit-slider-thumb {
     -webkit-appearance: none;
     appearance: none;
-    width: 20px;
-    height: 20px;
-    background: var(--thumb-color, #ffa500); /* Default orange color */
+    width: 18px;
+    height: 18px;
     border-radius: 50%;
-    cursor: pointer;
-    box-shadow: 0 0 5px var(--thumb-color, rgba(255, 165, 0, 0.8));
-    transition: transform 0.2s ease, background-color 0.2s ease;
+    background: var(--thumb-color, #ffb774);
+    box-shadow: 0 0 0 4px rgba(255, 183, 116, 0.18);
+    border: 1px solid rgba(255, 255, 255, 0.45);
+    transition: transform 0.2s ease, box-shadow 0.2s ease, background 0.2s ease;
 }
 
 #audioSlider::-webkit-slider-thumb:hover {
-    transform: scale(1.3);
-}
-
-#audioSlider.muted::-webkit-slider-thumb {
-    background: rgb(96, 0, 126);
-}
-
-#audioSlider.muted::-moz-range-thumb {
-    background: rgb(96, 0, 126); /* Purple when muted */
+    transform: scale(1.1);
+    box-shadow: 0 0 0 6px rgba(255, 183, 116, 0.22);
 }
 
 #audioSlider::-moz-range-thumb {
-    width: 15px;
-    height: 15px;
-    background: var(--thumb-color, #ffa500);
+    width: 18px;
+    height: 18px;
     border-radius: 50%;
-    cursor: pointer;
-    transition: background-color 0.2s ease;
+    background: var(--thumb-color, #ffb774);
+    border: 1px solid rgba(255, 255, 255, 0.45);
 }
 
-.slider-container {
-    display: flex;
-    align-items: center;
-    gap: 10px;
-    justify-content: center;
+#audioSlider.muted {
+    background: linear-gradient(90deg, rgba(116, 96, 186, 0.75) 100%, rgba(255, 255, 255, 0.12) 0%);
+}
+
+#audioSlider.muted::-webkit-slider-thumb,
+#audioSlider.muted::-moz-range-thumb {
+    background: #8060ba;
+    box-shadow: 0 0 0 4px rgba(128, 96, 186, 0.2);
 }
 
 #rollButton.disabled {
     pointer-events: none;
     opacity: 0.5;
     cursor: not-allowed;
-}
-
-.settingsBtns {
-    display: inline-block;
-    padding: 10px 15px;
-    margin: 10px 0;
-    font-size: 1rem;
-    font-weight: bold;
-    border: none;
-    border-radius: 5px;
-    cursor: pointer;
-    transition: all 0.3s ease-in-out;
 }
 
 .achievementsBtns {
@@ -2729,7 +2876,135 @@ body.griCutsceneBgImg {
 
 .inventory button:hover {
     background-color: #4169e1;
-    transform: scale(1.1);
+    transform: translateY(-1px);
+}
+
+.inventory-actions {
+  display: flex;
+  flex-direction: column;
+  gap: 18px;
+  margin-bottom: 18px;
+}
+
+.inventory-group {
+  --group-bg-a: rgba(18, 24, 38, 0.82);
+  --group-bg-b: rgba(10, 14, 24, 0.94);
+  --group-border: rgba(122, 164, 255, 0.18);
+  background: linear-gradient(180deg, var(--group-bg-a), var(--group-bg-b));
+  border: 1px solid var(--group-border);
+  border-radius: 14px;
+  padding: 14px 16px 18px 16px;
+  box-shadow: inset 0 0 0 1px rgba(255,255,255,0.015);
+}
+
+.inventory-group__header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 12px;
+  flex-wrap: wrap;
+  margin-bottom: 12px;
+}
+
+.inventory-group__title {
+  margin: 0;
+  font-size: 0.85rem;
+  text-transform: uppercase;
+  letter-spacing: 0.1em;
+  color: rgba(214, 226, 255, 0.88);
+}
+
+.inventory-group__clear {
+  padding: 6px 14px;
+  font-size: 0.8rem;
+  border-radius: 999px;
+  background: rgba(255, 255, 255, 0.08);
+  border: 1px solid rgba(140, 188, 255, 0.22);
+  color: #f6f9ff;
+}
+
+.inventory-group__clear:hover {
+  background: rgba(255, 255, 255, 0.14);
+  border-color: rgba(176, 214, 255, 0.4);
+}
+
+.inventory-group__grid {
+  display: grid;
+  gap: 10px;
+  grid-template-columns: repeat(auto-fit, minmax(130px, 1fr));
+}
+
+.inventory-delete-btn {
+  padding: 8px 10px;
+  border-radius: 12px;
+  border: 1px solid rgba(130, 172, 255, 0.25);
+  background: rgba(24, 34, 58, 0.78);
+  color: #f2f5ff;
+  font-size: 0.85rem;
+  line-height: 1.25;
+  white-space: normal;
+  word-break: keep-all;
+  transition: transform 0.2s ease, background 0.2s ease, border-color 0.2s ease;
+}
+
+.inventory-delete-btn span {
+  display: inline-block;
+}
+
+.inventory-delete-btn:hover {
+  transform: translateY(-1px);
+  background: rgba(50, 72, 118, 0.85);
+  border-color: rgba(176, 210, 255, 0.45);
+}
+
+.inventory-group--basic {
+  --group-bg-a: rgba(24, 46, 96, 0.72);
+  --group-bg-b: rgba(12, 24, 48, 0.92);
+  --group-border: rgba(108, 158, 255, 0.32);
+}
+
+.inventory-group--basic .inventory-delete-btn {
+  background: rgba(36, 58, 108, 0.78);
+}
+
+.inventory-group--decent {
+  --group-bg-a: rgba(20, 58, 60, 0.72);
+  --group-bg-b: rgba(10, 28, 36, 0.92);
+  --group-border: rgba(118, 228, 195, 0.28);
+}
+
+.inventory-group--decent .inventory-delete-btn {
+  background: rgba(24, 66, 66, 0.76);
+}
+
+.inventory-group--grand {
+  --group-bg-a: rgba(34, 68, 38, 0.72);
+  --group-bg-b: rgba(16, 28, 24, 0.92);
+  --group-border: rgba(138, 236, 160, 0.28);
+}
+
+.inventory-group--events {
+  --group-bg-a: rgba(82, 46, 22, 0.74);
+  --group-bg-b: rgba(40, 18, 10, 0.92);
+  --group-border: rgba(255, 190, 120, 0.32);
+}
+
+.inventory-group--special {
+  --group-bg-a: rgba(70, 32, 82, 0.72);
+  --group-bg-b: rgba(32, 14, 46, 0.92);
+  --group-border: rgba(220, 160, 255, 0.32);
+}
+
+.inventory-group--mastery {
+  --group-bg-a: rgba(82, 42, 28, 0.74);
+  --group-bg-b: rgba(36, 18, 12, 0.92);
+  --group-border: rgba(255, 172, 140, 0.3);
+}
+
+.inventory-group--supreme {
+  --group-bg-a: rgba(68, 28, 74, 0.72);
+  --group-bg-b: rgba(28, 12, 36, 0.92);
+  --group-border: rgba(224, 156, 255, 0.32);
 }
 
 #toggleInventoryBtn {
@@ -3072,6 +3347,14 @@ body.griCutsceneBgImg {
     z-index: 1000000000;
 }
 
+.loading-content {
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    gap: 18px;
+    text-align: center;
+}
+
 .loading-animation {
     border: 5px solid #f3f3f3;
     border-top: 5px solid #3498db;
@@ -3083,7 +3366,10 @@ body.griCutsceneBgImg {
 }
 
 .loadTxt {
-    margin-top: 20px;
+    margin: 0;
+    font-size: 1.1rem;
+    font-weight: 600;
+    letter-spacing: .04em;
 }
 
 @keyframes spin {
@@ -3563,24 +3849,85 @@ body.griCutsceneBgImg {
     text-transform: uppercase;
 }
 
-.achievement-popup {
+.achievement-toast-stack {
     position: fixed;
     left: 50%;
-    bottom: -50px;
+    bottom: 48px;
     transform: translateX(-50%);
-    background: rgba(0, 0, 0, 0.8);
-    color: white;
-    padding: 10px 20px;
-    border-radius: 10px;
-    font-size: 18px;
-    opacity: 0;
+    display: flex;
+    flex-direction: column;
+    gap: 12px;
+    pointer-events: none;
     z-index: 99999999900;
-    transition: bottom 0.5s ease-out, opacity 0.5s ease-out;
 }
 
-.achievement-popup.show {
-    bottom: 90px;
+.achievement-toast {
+    display: flex;
+    align-items: center;
+    gap: 14px;
+    min-width: 260px;
+    max-width: min(420px, calc(100vw - 32px));
+    padding: 14px 18px;
+    background: linear-gradient(135deg, rgba(35, 46, 78, 0.92), rgba(18, 22, 38, 0.92));
+    border: 1px solid rgba(132, 184, 255, 0.35);
+    border-radius: 16px;
+    box-shadow: 0 22px 46px rgba(0, 0, 0, 0.45);
+    color: #f7fbff;
+    transform: translateY(110%);
+    opacity: 0;
+    transition: transform 0.45s cubic-bezier(.22,1,.36,1), opacity 0.45s ease;
+}
+
+.achievement-toast.show {
+    transform: translateY(0);
     opacity: 1;
+}
+
+.achievement-toast.hide {
+    transform: translateY(40%);
+    opacity: 0;
+}
+
+.achievement-toast__icon {
+    width: 46px;
+    height: 46px;
+    border-radius: 50%;
+    background: radial-gradient(circle at 30% 30%, rgba(255, 215, 120, 0.95), rgba(244, 138, 70, 0.9));
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    color: #1a1420;
+    font-size: 1.4rem;
+    box-shadow: 0 8px 18px rgba(244, 138, 70, 0.45);
+}
+
+.achievement-toast__content {
+    display: flex;
+    flex-direction: column;
+    gap: 4px;
+}
+
+.achievement-toast__title {
+    font-size: 0.8rem;
+    letter-spacing: 0.16em;
+    text-transform: uppercase;
+    color: rgba(255, 255, 255, 0.78);
+}
+
+.achievement-toast__name {
+    font-size: 1.05rem;
+    font-weight: 600;
+    color: #fdf8ff;
+}
+
+@media (prefers-reduced-motion: reduce) {
+    .achievement-toast,
+    .achievement-toast.show,
+    .achievement-toast.hide {
+        transition: none;
+        transform: none;
+        opacity: 1;
+    }
 }
 
 .achievement-grid {

--- a/index.html
+++ b/index.html
@@ -27,62 +27,73 @@
         <button id="startButton"><i class="fa-solid fa-play"></i></button>
     </div>
     <div id="loadingScreen">
-        <div>
+        <div class="loading-content">
             <div class="loading-animation"></div>
             <p class="loadTxt">Loading assets...</p>
         </div>
-  </div>
-    
-    <div id="settingsMenu" class="settings-menu" style="display: none;"> <h3 class="dragTxt">Hold me to drag</h3>
-        <div class="rollsCount1">
-            <h3>Settings</h3>
-        
-            <div class="setting-item">
-                <label class="aSlid" for="audioSlider">Audio Volume:</label>
-                <div class="original-parent">
-                    <div class="slider-container">
-                      <input type="range" id="audioSlider" min="0" max="1" step="0.01" value="1">
-                      <button id="muteButton" class="settingsBtns">Mute</button>
+    </div>
+
+    <div id="settingsMenu" class="settings-menu" style="display: none;">
+        <div class="settings-panel">
+            <div class="settings-header">
+                <h3 class="dragTxt">Settings</h3>
+                <button id="closeSettings" class="settings-close-btn" type="button">Close</button>
+            </div>
+            <div class="settings-body">
+                <section class="settings-section">
+                    <h4 class="settings-section__title">Audio</h4>
+                    <div class="settings-audio">
+                        <label class="settings-audio__label" for="audioSlider">Master Volume</label>
+                        <div class="settings-audio__controls">
+                            <div class="settings-audio__slider">
+                                <input type="range" id="audioSlider" min="0" max="1" step="0.01" value="1">
+                                <span id="audioSliderValue" class="settings-audio__value">100%</span>
+                            </div>
+                            <button id="muteButton" class="settings-btn settings-btn--ghost" type="button">Mute</button>
+                        </div>
                     </div>
-                </div>
-            </div>
-        
-            <div class="setting-item">
-                <button id="resetDataButton" class="settingsBtns">Reset Data</button>
-            </div>
-            <div class="setting-item">
-                <button id="toggleRollDisplayBtn" class="settingsBtns">Hide Roll & Display</button>
-                <button id="toggleRollHistoryBtn" class="settingsBtns">Hide Roll History</button>
-            </div>
+                </section>
 
-            <div class="setting-item">
-                <button id="saveButton" class="settingsBtns">Save Data</button>
-                <button id="importButton" class="settingsBtns">Import Data</button>
-                <p id="status" class="statusImport"></p>
-            </div>
+                <section class="settings-section">
+                    <h4 class="settings-section__title">Data Management</h4>
+                    <div class="settings-grid">
+                        <button id="saveButton" class="settings-btn" type="button">Save Data</button>
+                        <button id="importButton" class="settings-btn" type="button">Import Data</button>
+                        <button id="resetDataButton" class="settings-btn settings-btn--danger" type="button">Reset Data</button>
+                    </div>
+                    <p id="status" class="statusImport"></p>
+                </section>
 
-            <div class="settings-item">
-                <h3 class="SkipCutsceneTxt">Skip Cutscene Rarity</h3>
-                <div id="rarityChecklistC">
-                    <button id="toggleCutscene1K" class="cutsceneSkipBtb"><a id="1KTxt" class="under1kT">Skip Decent Cutscenes</a></button>
-                    <button id="toggleCutscene10K" class="cutsceneSkipBtb"><a id="10KTxt" class="under10kT">Skip Grand Cutscenes</a></button>
-                    <button id="toggleCutscene100K" class="cutsceneSkipBtb"><a id="100KTxt" class="under100k">Skip Mastery Cutscenes</a></button>
-                    <button id="toggleCutscene1M" class="cutsceneSkipBtb"><a id="1MTxt" class="under1mBtn">Skip Supreme Cutscenes</a></button>
-                </div>
+                <section class="settings-section">
+                    <h4 class="settings-section__title">Interface</h4>
+                    <div class="settings-grid">
+                        <button id="toggleRollDisplayBtn" class="settings-btn settings-btn--ghost" type="button">Hide Roll &amp; Display</button>
+                        <button id="toggleRollHistoryBtn" class="settings-btn settings-btn--ghost" type="button">Hide Roll History</button>
+                    </div>
+                </section>
+
+                <section class="settings-section">
+                    <h4 class="settings-section__title">Cutscene Skip</h4>
+                    <div id="rarityChecklistC" class="settings-chip-group">
+                        <button id="toggleCutscene1K" class="cutsceneSkipBtb" type="button"><span id="1KTxt" class="under1kT">Skip Decent Cutscenes</span></button>
+                        <button id="toggleCutscene10K" class="cutsceneSkipBtb" type="button"><span id="10KTxt" class="under10kT">Skip Grand Cutscenes</span></button>
+                        <button id="toggleCutscene100K" class="cutsceneSkipBtb" type="button"><span id="100KTxt" class="under100k">Skip Mastery Cutscenes</span></button>
+                        <button id="toggleCutscene1M" class="cutsceneSkipBtb" type="button"><span id="1MTxt" class="under1mBtn">Skip Supreme Cutscenes</span></button>
+                    </div>
+                </section>
+
+                <section class="settings-section">
+                    <h4 class="settings-section__title">Auto Delete Rarity</h4>
+                    <div id="rarityChecklist" class="settings-chip-group">
+                        <button class="rarity-button" data-rarity="under100" type="button"><span class="under100T">Basic</span></button>
+                        <button class="rarity-button" data-rarity="under1k" type="button"><span class="under1kT">Decent</span></button>
+                        <button class="rarity-button" data-rarity="under10k" type="button"><span class="under10kT">Grand</span></button>
+                        <button class="rarity-button" data-rarity="under100k" type="button"><span class="under100k">Mastery</span></button>
+                        <button class="rarity-button" data-rarity="under1m" type="button"><span class="under1mBtn">Supreme</span></button>
+                        <button class="rarity-button" data-rarity="special" type="button"><span class="special">Special</span></button>
+                    </div>
+                </section>
             </div>
-            <div class="settings-item">
-                <h3 class="AutoDeletionTxt">Auto delete Rarity</h2>
-                <div id="rarityChecklist">
-                    <button class="rarity-button" data-rarity="under100"><a class="under100T">Basic</a></button>
-                    <button class="rarity-button" data-rarity="under1k"><a class="under1kT">Decent</a></button>
-                    <button class="rarity-button" data-rarity="under10k"><a class="under10kT">Grand</a></button>
-                    <button class="rarity-button" data-rarity="under100k"><a class="under100k">Mastery</a></button>
-                    <button class="rarity-button" data-rarity="under1m"><a class="under1mBtn">Supreme</a></button>
-                    <button class="rarity-button" data-rarity="special"><a class="special">Special</a></button>
-                </div>                  
-            </div>
-                    
-            <button id="closeSettings" class="settingsBtns">Close</button>
         </div>
     </div>
 
@@ -237,241 +248,175 @@
             <div class="invent">
                 <h2><i class="fa-solid fa-box-archive"></i> Inventory</h2>
 
-                <button class="deleteAll" id="deleteAllButton">Delete All</button>
+                <div class="inventory-actions">
+                    <button class="deleteAll" id="deleteAllButton" type="button">Delete Entire Inventory</button>
 
-                <button id="deleteAllUnder100Button" class="buttonDivClass">
-                    <p class="under100T">Delete All Basic</p>
-                </button>
-                <button id="deleteAllCommonButton" class="under100">Delete All Common</button>
-                <button id="deleteAllRareButton" class="under100">Delete All Rare</button>
-                <button id="deleteAllEpicButton" class="under100">Delete All Epic</button>
-                <button id="deleteAllLegendaryButton" class="under100">Delete All Legendary</button>
-                <button id="deleteAllImpossibleButton" class="under100">Delete All Impossible</button>
-                <button id="deleteAllPoweredButton" class="under100">Delete All Powered</button>
-                <button id="deleteAllToxicButton" class="under100">Delete All Toxic</button>
-                <button id="deleteAllSolarpowerButton" class="under100">Delete All Solarpower</button>
-                <button id="deleteAllFlickerButton" class="under100">Delete All Flicker</button>
-                <button id="deleteAllBelieverButton" class="under100">Delete All Believer</button>
-                <button id="deleteAllPlanetBreakerButton" class="under100">Delete All Planet Breaker</button>
+                    <section class="inventory-group inventory-group--basic">
+                        <div class="inventory-group__header">
+                            <h4 class="inventory-group__title">Basic Titles</h4>
+                            <button id="deleteAllUnder100Button" class="inventory-group__clear" type="button">Clear Basic</button>
+                        </div>
+                        <div class="inventory-group__grid">
+                            <button id="deleteAllCommonButton" class="inventory-delete-btn" type="button" title="Delete All Common">Common</button>
+                            <button id="deleteAllRareButton" class="inventory-delete-btn" type="button" title="Delete All Rare">Rare</button>
+                            <button id="deleteAllEpicButton" class="inventory-delete-btn" type="button" title="Delete All Epic">Epic</button>
+                            <button id="deleteAllLegendaryButton" class="inventory-delete-btn" type="button" title="Delete All Legendary">Legendary</button>
+                            <button id="deleteAllImpossibleButton" class="inventory-delete-btn" type="button" title="Delete All Impossible">Impossible</button>
+                            <button id="deleteAllPoweredButton" class="inventory-delete-btn" type="button" title="Delete All Powered">Powered</button>
+                            <button id="deleteAllToxicButton" class="inventory-delete-btn" type="button" title="Delete All Toxic">Toxic</button>
+                            <button id="deleteAllSolarpowerButton" class="inventory-delete-btn" type="button" title="Delete All Solarpower">Solarpower</button>
+                            <button id="deleteAllFlickerButton" class="inventory-delete-btn" type="button" title="Delete All Flicker">Flicker</button>
+                            <button id="deleteAllBelieverButton" class="inventory-delete-btn" type="button" title="Delete All Believer">Believer</button>
+                            <button id="deleteAllPlanetBreakerButton" class="inventory-delete-btn" type="button" title="Delete All Planet Breaker">Planet Breaker</button>
+                        </div>
+                    </section>
 
-                <button id="deleteAllUnder1kButton" class="buttonDivClass">
-                    <p class="under1kT">Delete All Decent</p>
-                </button>
-                <button id="deleteAllUnstoppableButton" class="under1k">Delete All Unstoppable</button>
-                <button id="deleteAllGargantuaButton" class="under1k">Delete All Gargantua</button>
-                <button id="deleteAllWanderingSpiritButton" class="under1k">Delete All Wandering Spirit</button>
-                <button id="deleteAllMemoryButton" class="under1k">Delete All Memory</button>
-                <button id="deleteAllOblivionButton" class="under1k">Delete All Oblivion</button>
-                <button id="deleteAllFrozenFateButton" class="under1k">Delete All Frozen Fate</button>
-                <button id="deleteAllSpectralButton" class="under1k">Delete All Spectral Whisper</button>
-                <button id="deleteAllMysteriousEchoButton" class="under1k">Delete All Mysterious Echo</button>
-                <button id="deleteAllIsekaiButton" class="under1k">Delete All Isekai</button>
-                <button id="deleteAllIsekaiLofiButton" class="under10k">Delete All Isekai: Lo-fi</button>
-                <button id="deleteAllForgottenWhisperButton" class="under1k">Delete All Forgotten Whisper</button>
-                <button id="deleteAllEmergenciesButton" class="under1k">Delete All Emergencies</button>
-                <button id="deleteAllStarfallButton" class="under1k">Delete All Starfall</button>
-                <button id="deleteAllCursedArtifactButton" class="under1k">Delete All Cursed Artifact</button>
-                <button id="deleteAllSamuraiButton" class="under1k">Delete All Samurai</button>
-                <button id="deleteAllSpectralGlareButton" class="under1k">Delete All Spectral Glare</button>
-                <button id="deleteAllPhantomStrideButton" class="under1k">Delete All Phantom Stride</button>
-                <button id="deleteAllContortionsButton" class="under1k">Delete All Contortions</button>
+                    <section class="inventory-group inventory-group--decent">
+                        <div class="inventory-group__header">
+                            <h4 class="inventory-group__title">Decent Titles</h4>
+                            <button id="deleteAllUnder1kButton" class="inventory-group__clear" type="button">Clear Decent</button>
+                        </div>
+                        <div class="inventory-group__grid">
+                            <button id="deleteAllUnstoppableButton" class="inventory-delete-btn" type="button" title="Delete All Unstoppable">Unstoppable</button>
+                            <button id="deleteAllGargantuaButton" class="inventory-delete-btn" type="button" title="Delete All Gargantua">Gargantua</button>
+                            <button id="deleteAllWanderingSpiritButton" class="inventory-delete-btn" type="button" title="Delete All Wandering Spirit">Wandering Spirit</button>
+                            <button id="deleteAllMemoryButton" class="inventory-delete-btn" type="button" title="Delete All Memory">Memory</button>
+                            <button id="deleteAllOblivionButton" class="inventory-delete-btn" type="button" title="Delete All Oblivion">Oblivion</button>
+                            <button id="deleteAllFrozenFateButton" class="inventory-delete-btn" type="button" title="Delete All Frozen Fate">Frozen Fate</button>
+                            <button id="deleteAllSpectralButton" class="inventory-delete-btn" type="button" title="Delete All Spectral Whisper">Spectral Whisper</button>
+                            <button id="deleteAllMysteriousEchoButton" class="inventory-delete-btn" type="button" title="Delete All Mysterious Echo">Mysterious Echo</button>
+                            <button id="deleteAllIsekaiButton" class="inventory-delete-btn" type="button" title="Delete All Isekai">Isekai</button>
+                            <button id="deleteAllForgottenWhisperButton" class="inventory-delete-btn" type="button" title="Delete All Forgotten Whisper">Forgotten Whisper</button>
+                            <button id="deleteAllEmergenciesButton" class="inventory-delete-btn" type="button" title="Delete All Emergencies">Emergencies</button>
+                            <button id="deleteAllStarfallButton" class="inventory-delete-btn" type="button" title="Delete All Starfall">Starfall</button>
+                            <button id="deleteAllCursedArtifactButton" class="inventory-delete-btn" type="button" title="Delete All Cursed Artifact">Cursed Artifact</button>
+                            <button id="deleteAllSamuraiButton" class="inventory-delete-btn" type="button" title="Delete All Samurai">Samurai</button>
+                            <button id="deleteAllSpectralGlareButton" class="inventory-delete-btn" type="button" title="Delete All Spectral Glare">Spectral Glare</button>
+                            <button id="deleteAllPhantomStrideButton" class="inventory-delete-btn" type="button" title="Delete All Phantom Stride">Phantom Stride</button>
+                            <button id="deleteAllContortionsButton" class="inventory-delete-btn" type="button" title="Delete All Contortions">Contortions</button>
+                            <button id="deleteAllIsekaiLofiButton" class="inventory-delete-btn" type="button" title="Delete All Isekai: Lo-fi">Isekai: Lo-fi</button>
+                        </div>
+                    </section>
 
-                <button id="deleteAllUnder10kButton" class="buttonDivClass">
-                    <p class="under10kT">Delete All Grand</p>
-                </button>
-                <button id="deleteAllShadowVeilButton" class="under10k">Delete All Shadow Veil</button>
-                <button id="deleteAllFrightButton" class="under10k">Delete All Fright</button>
-                <button id="deleteAllNightfallButton" class="under10k">Delete All Nightfall</button>
-                <button id="deleteAllFearButton"  class="under10k">Delete All Fear</button>
-                <button id="deleteAllSeraphsWingButton" class="under10k">Delete All Seraph's Wing</button>
-                <button id="deleteAllVoidWalkerButton" class="under10k">Delete All Void Walker</button>
-                <button id="deleteAllHauntedSoulButton" class="under10k">Delete All Haunted Soul</button>
-                <button id="deleteAllGDAddictButton" class="under10k">Delete All GD Addict</button>
-                <button id="deleteAllSilentListenerButton" class="under10k">Delete All Silent Listener</button>
-                <button id="deleteAllGhostlyEmbraceButton" class="under10k">Delete All Ghostly Embrace</button>
-                <button id="deleteAllEndlessTwilightButton" class="under10k">Delete All Endless Twilight</button>
-                <button id="deleteAllLostSoulButton" class="under10k">Delete All Lost Soul</button>
-                <button id="deleteAllAbyssalShadeButton" class="under10k">Delete All Abyssal Shade</button>
-                <button id="deleteAllDarkenedSkyButton" class="under10k">Delete All Darkened Sky</button>
-                <button id="deleteAllShad0wButton" class="under10k">Delete All Shad0w</button>
-                <button id="deleteAllTwistedLightButton" class="under10k">Delete All Twisted Light</button>
-                <button id="deleteAllFoundSoulButton" class="under10k">Delete All Found Soul</button>
-                <button id="deleteAllHauntedRealityButton" class="under10k">Delete All Haunted Reality</button>
-                <button id="deleteAllLubJubButton" class="under10k">Delete All LubbyJubby's Cherry Grove</button>
-                <button id="deleteAllEtherShiftButton" class="under10k">Delete All Ether Shift</button>
-                <button id="deleteAllEtherealPulseButton" class="under10k">Delete All Ethereal Pulse</button>
-                <button id="deleteAllHellishFireButton" class="under10k">Delete All Hellish Fire</button>
-                <button id="deleteAllRadButton" class="under10k">Delete All Rad</button>
-                <button id="deleteAllEnigmaticDreamButton" class="under10k">Delete All Enigmatic Dream</button>
-                <button id="deleteAllGrimDestinyButton" class="under10k">Delete All Grim Destiny</button>
-                <button id="deleteAllDemonSoulButton" class="under10k">Delete All Demon Soul</button>
+                    <section class="inventory-group inventory-group--grand">
+                        <div class="inventory-group__header">
+                            <h4 class="inventory-group__title">Grand Titles</h4>
+                            <button id="deleteAllUnder10kButton" class="inventory-group__clear" type="button">Clear Grand</button>
+                        </div>
+                        <div class="inventory-group__grid">
+                            <button id="deleteAllShadowVeilButton" class="inventory-delete-btn" type="button" title="Delete All Shadow Veil">Shadow Veil</button>
+                            <button id="deleteAllFrightButton" class="inventory-delete-btn" type="button" title="Delete All Fright">Fright</button>
+                            <button id="deleteAllNightfallButton" class="inventory-delete-btn" type="button" title="Delete All Nightfall">Nightfall</button>
+                            <button id="deleteAllFearButton" class="inventory-delete-btn" type="button" title="Delete All Fear">Fear</button>
+                            <button id="deleteAllSeraphsWingButton" class="inventory-delete-btn" type="button" title="Delete All Seraph's Wing">Seraph's Wing</button>
+                            <button id="deleteAllVoidWalkerButton" class="inventory-delete-btn" type="button" title="Delete All Void Walker">Void Walker</button>
+                            <button id="deleteAllHauntedSoulButton" class="inventory-delete-btn" type="button" title="Delete All Haunted Soul">Haunted Soul</button>
+                            <button id="deleteAllGDAddictButton" class="inventory-delete-btn" type="button" title="Delete All GD Addict">GD Addict</button>
+                            <button id="deleteAllSilentListenerButton" class="inventory-delete-btn" type="button" title="Delete All Silent Listener">Silent Listener</button>
+                            <button id="deleteAllGhostlyEmbraceButton" class="inventory-delete-btn" type="button" title="Delete All Ghostly Embrace">Ghostly Embrace</button>
+                            <button id="deleteAllEndlessTwilightButton" class="inventory-delete-btn" type="button" title="Delete All Endless Twilight">Endless Twilight</button>
+                            <button id="deleteAllLostSoulButton" class="inventory-delete-btn" type="button" title="Delete All Lost Soul">Lost Soul</button>
+                            <button id="deleteAllAbyssalShadeButton" class="inventory-delete-btn" type="button" title="Delete All Abyssal Shade">Abyssal Shade</button>
+                            <button id="deleteAllDarkenedSkyButton" class="inventory-delete-btn" type="button" title="Delete All Darkened Sky">Darkened Sky</button>
+                            <button id="deleteAllShad0wButton" class="inventory-delete-btn" type="button" title="Delete All Shad0w">Shad0w</button>
+                            <button id="deleteAllTwistedLightButton" class="inventory-delete-btn" type="button" title="Delete All Twisted Light">Twisted Light</button>
+                            <button id="deleteAllFoundSoulButton" class="inventory-delete-btn" type="button" title="Delete All Found Soul">Found Soul</button>
+                            <button id="deleteAllHauntedRealityButton" class="inventory-delete-btn" type="button" title="Delete All Haunted Reality">Haunted Reality</button>
+                            <button id="deleteAllLubJubButton" class="inventory-delete-btn" type="button" title="Delete All LubbyJubby's Cherry Grove">LubbyJubby's Cherry Grove</button>
+                            <button id="deleteAllEtherShiftButton" class="inventory-delete-btn" type="button" title="Delete All Ether Shift">Ether Shift</button>
+                            <button id="deleteAllEtherealPulseButton" class="inventory-delete-btn" type="button" title="Delete All Ethereal Pulse">Ethereal Pulse</button>
+                            <button id="deleteAllHellishFireButton" class="inventory-delete-btn" type="button" title="Delete All Hellish Fire">Hellish Fire</button>
+                            <button id="deleteAllRadButton" class="inventory-delete-btn" type="button" title="Delete All Rad">Rad</button>
+                            <button id="deleteAllEnigmaticDreamButton" class="inventory-delete-btn" type="button" title="Delete All Enigmatic Dream">Enigmatic Dream</button>
+                            <button id="deleteAllGrimDestinyButton" class="inventory-delete-btn" type="button" title="Delete All Grim Destiny">Grim Destiny</button>
+                            <button id="deleteAllDemonSoulButton" class="inventory-delete-btn" type="button" title="Delete All Demon Soul">Demon Soul</button>
+                        </div>
+                    </section>
 
-                <button id="deleteAllPumpkinButton" class="eventTitleHalloween">Delete All Pumpkin</button>
+                    <section class="inventory-group inventory-group--events">
+                        <div class="inventory-group__header">
+                            <h4 class="inventory-group__title">Event Titles</h4>
+                        </div>
+                        <div class="inventory-group__grid">
+                            <button id="deleteAllPumpkinButton" class="inventory-delete-btn" type="button" title="Delete All Pumpkin">Pumpkin</button>
+                            <button id="deleteAllCrimsonStockingsButton" class="inventory-delete-btn" type="button" title="Delete All Crimson Stockings"><span class="eventTitleXmas">Crimson Stockings</span></button>
+                            <button id="deleteAllHolidayCheerButton" class="inventory-delete-btn" type="button" title="Delete All Holiday Cheer"><span class="eventTitleXmas">Holiday Cheer</span></button>
+                            <button id="deleteAllReindeerDashButton" class="inventory-delete-btn" type="button" title="Delete All Reindeer Dash"><span class="eventTitleXmas">Reindeer Dash</span></button>
+                            <button id="deleteAllGingerbreadHarmonyButton" class="inventory-delete-btn" type="button" title="Delete All Gingerbread Harmony"><span class="eventTitleXmas">Gingerbread Harmony</span></button>
+                            <button id="deleteAllSilentNightButton" class="inventory-delete-btn" type="button" title="Delete All Silent Night"><span class="eventTitleXmas">Silent Night</span></button>
+                            <button id="deleteAllFrostedGarlandButton" class="inventory-delete-btn" type="button" title="Delete All Frosted Garland"><span class="eventTitleXmas">Frosted Garland</span></button>
+                            <button id="deleteAllCandyCaneSymphonyButton" class="inventory-delete-btn" type="button" title="Delete All Candy Cane Symphony"><span class="eventTitleXmas">Candy Cane Symphony</span></button>
+                            <button id="deleteAllSantaClausButton" class="inventory-delete-btn" type="button" title="Delete All Santa Claus"><span class="eventTitleXmas">Santa Claus</span></button>
+                            <button id="deleteAllJollyBellsButton" class="inventory-delete-btn" type="button" title="Delete All Jolly Bells"><span class="eventTitleXmas">Jolly Bells</span></button>
+                            <button id="deleteAllNorthStarButton" class="inventory-delete-btn" type="button" title="Delete All North Star"><span class="eventTitleXmas">North Star</span></button>
+                            <button id="deleteAllFircraButton" class="inventory-delete-btn" type="button" title="Delete All Firecracker"><span class="eventTitle">Firecracker</span></button>
+                            <button id="deleteAllHeartButton" class="inventory-delete-btn" type="button" title="Delete All Heart"><span class="eventV">Heart</span></button>
+                            <button id="deleteAllEasterEggButton" class="inventory-delete-btn" type="button" title="Delete All Easter Egg"><span class="eventE">Easter Egg</span></button>
+                            <button id="deleteAllEasterBunnyButton" class="inventory-delete-btn" type="button" title="Delete All Easter Bunny"><span class="eventE">Easter Bunny</span></button>
+                            <button id="deleteAllWaveButton" class="inventory-delete-btn" type="button" title="Delete All Wave"><span class="eventS">Wave</span></button>
+                            <button id="deleteAllScorchingButton" class="inventory-delete-btn" type="button" title="Delete All Scorching"><span class="eventS">Scorching</span></button>
+                            <button id="deleteAllBeachButton" class="inventory-delete-btn" type="button" title="Delete All Beach"><span class="eventS">Beach</span></button>
+                            <button id="deleteAllTidalWaveButton" class="inventory-delete-btn" type="button" title="Delete All Tidal Wave"><span class="eventS">Tidal Wave</span></button>
+                        </div>
+                    </section>
 
-                <button id="deleteAllCrimsonStockingsButton" class="buttonDiv">
-                    <p class="eventTitleXmas">Delete All Crimson Stockings</p>
-                    </button>
-                <button id="deleteAllHolidayCheerButton" class="buttonDiv">
-                    <p class="eventTitleXmas">Delete All Holiday Cheer</p>
-                    </button>
-                <button id="deleteAllReindeerDashButton" class="buttonDiv">
-                    <p class="eventTitleXmas">Delete All Reindeer Dash</p>
-                    </button>
-                <button id="deleteAllGingerbreadHarmonyButton" class="buttonDiv">
-                    <p class="eventTitleXmas">Delete All Gingerbread Harmony</p>
-                    </button>
-                <button id="deleteAllSilentNightButton" class="buttonDiv">
-                    <p class="eventTitleXmas">Delete All Silent Night</p>
-                    </button>
-                <button id="deleteAllFrostedGarlandButton" class="buttonDiv">
-                    <p class="eventTitleXmas">Delete All Frosted Garland</p>
-                    </button>
-                <button id="deleteAllCandyCaneSymphonyButton" class="buttonDiv">
-                    <p class="eventTitleXmas">Delete All Candy Cane Symphony</p>
-                    </button>
-                <button id="deleteAllSantaClausButton" class="buttonDiv">
-                    <p class="eventTitleXmas">Delete All Santa Claus</p>
-                    </button>
-                <button id="deleteAllJollyBellsButton" class="buttonDiv">
-                    <p class="eventTitleXmas">Delete All Jolly Bells</p>
-                    </button>
-                <button id="deleteAllNorthStarButton" class="buttonDiv">
-                    <p class="eventTitleXmas">Delete All North Star</p>
-                    </button>
+                    <section class="inventory-group inventory-group--special">
+                        <div class="inventory-group__header">
+                            <h4 class="inventory-group__title">Special Titles</h4>
+                            <button id="deleteAllSpecialButton" class="inventory-group__clear" type="button"><span class="special">Clear Special</span></button>
+                        </div>
+                        <div class="inventory-group__grid">
+                            <button id="deleteAllVeilButton" class="inventory-delete-btn" type="button" title="Delete All Veil"><span class="special">Veil</span></button>
+                            <button id="deleteAllExperimentButton" class="inventory-delete-btn" type="button" title="Delete All Experiment"><span class="special">Experiment</span></button>
+                            <button id="deleteAllAbominationButton" class="inventory-delete-btn" type="button" title="Delete All Abomination"><span class="special">Abomination</span></button>
+                            <button id="deleteAllIridocyclitisVeilButton" class="inventory-delete-btn" type="button" title="Delete All Iridocyclitis Veil"><span class="special">Iridocyclitis Veil</span></button>
+                            <button id="deleteAllBlindGTButton" class="inventory-delete-btn" type="button" title="Delete All BlindGT"><span class="special">BlindGT</span></button>
+                            <button id="deleteAllMSFUButton" class="inventory-delete-btn" type="button" title="Delete All MSFU"><span class="special">MSFU</span></button>
+                            <button id="deleteAllOrbButton" class="inventory-delete-btn" type="button" title="Delete All Orb"><span class="special">Orb</span></button>
+                            <button id="deleteAllFireCrazeButton" class="inventory-delete-btn" type="button" title="Delete All FireCraze"><span class="special">FireCraze</span></button>
+                            <button id="deleteAllShenviiButton" class="inventory-delete-btn" type="button" title="Delete All sʜeɴvɪ✞∞"><span class="special">sʜeɴvɪ✞∞</span></button>
+                        </div>
+                    </section>
 
-                <button id="deleteAllFircraButton" class="buttonDiv">
-                    <p class="eventTitle">Delete All Firecracker</p>
-                </button>
+                    <section class="inventory-group inventory-group--mastery">
+                        <div class="inventory-group__header">
+                            <h4 class="inventory-group__title">Mastery Titles</h4>
+                            <button id="deleteAllUnder100kButton" class="inventory-group__clear" type="button">Clear Mastery</button>
+                        </div>
+                        <div class="inventory-group__grid">
+                            <button id="deleteAllUnfairButton" class="inventory-delete-btn" type="button" title="Delete All Unfair">Unfair</button>
+                            <button id="deleteAllCursedMirageButton" class="inventory-delete-btn" type="button" title="Delete All Cursed Mirage">Cursed Mirage</button>
+                            <button id="deleteAllCelestialDawnButton" class="inventory-delete-btn" type="button" title="Delete All Celestial Dawn">Celestial Dawn</button>
+                            <button id="deleteAllFatesRequiemButton" class="inventory-delete-btn" type="button" title="Delete All Fate's Requiem">Fate's Requiem</button>
+                            <button id="deleteAllEonbreakButton" class="inventory-delete-btn" type="button" title="Delete All Eonbreak">Eonbreak</button>
+                            <button id="deleteAllOvertureButton" class="inventory-delete-btn" type="button" title="Delete All Overture">Overture</button>
+                            <button id="deleteAllLightButton" class="inventory-delete-btn" type="button" title="Delete All Light">Light</button>
+                            <button id="deleteAllUnnamedButton" class="inventory-delete-btn" type="button" title="Delete All Unnamed">Unnamed</button>
+                            <button id="deleteAllQbearButton" class="inventory-delete-btn" type="button" title="Delete All Qbear">Qbear</button>
+                            <button id="deleteAllBlodhestButton" class="inventory-delete-btn" type="button" title="Delete All Blodhest">Blodhest</button>
+                            <button id="deleteAllHarvButton" class="inventory-delete-btn" type="button" title="Delete All HARV">HARV</button>
+                            <button id="deleteAllTuonButton" class="inventory-delete-btn" type="button" title="Delete All Tuon">Tuon</button>
+                            <button id="deleteAllDevilsHeartButton" class="inventory-delete-btn" type="button" title="Delete All Devil's Heart">Devil's Heart</button>
+                            <button id="deleteAllArcanePulseButton" class="inventory-delete-btn" type="button" title="Delete All Arcane Pulse">Arcane Pulse</button>
+                        </div>
+                    </section>
 
-                <button id="deleteAllHeartButton" class="buttonDiv">
-                    <p class="eventV">Delete All Heart</p>
-                </button>
-
-                <button id="deleteAllEasterEggButton" class="buttonDiv">
-                    <p class="eventE">Delete All Easter Egg</p>
-                </button>
-                <button id="deleteAllEasterBunnyButton" class="buttonDiv">
-                    <p class="eventE">Delete All Easter Bunny</p>
-                </button>
-
-                <button id="deleteAllWaveButton" class="buttonDiv">
-                    <p class="eventS">Delete All Wave</p>
-                </button>
-                <button id="deleteAllScorchingButton" class="buttonDiv">
-                    <p class="eventS">Delete All Scorching</p>
-                </button>
-                <button id="deleteAllBeachButton" class="buttonDiv">
-                    <p class="eventS">Delete All Beach</p>
-                </button>
-                <button id="deleteAllTidalWaveButton" class="buttonDiv">
-                    <p class="eventS">Delete All Tidal Wave</p>
-                </button>
-
-                <button id="deleteAllSpecialButton" class="buttonDivClass">
-                    <p class="special">Delete All Special</p>
-                </button>
-                <button id="deleteAllVeilButton" class="buttonDiv">
-                    <p class="special">Delete All Veil</p>
-                </button>
-                <button id="deleteAllExperimentButton" class="buttonDiv">
-                    <p class="special">Delete All Experiment</p>
-                </button>
-                <button id="deleteAllAbominationButton" class="buttonDiv">
-                    <p class="special">Delete All Abomination</p>
-                </button>
-                <button id="deleteAllIridocyclitisVeilButton" class="buttonDiv">
-                    <p class="special">Delete All Iridocyclitis Veil</p>
-                </button>
-                <button id="deleteAllBlindGTButton" class="buttonDiv">
-                    <p class="special">Delete All BlindGT</p>
-                </button>
-                <button id="deleteAllMSFUButton" class="buttonDiv">
-                    <p class="special">Delete All MSFU</p>
-                </button>
-                <button id="deleteAllOrbButton" class="buttonDiv">
-                    <p class="special">Delete All Orb</p>
-                </button>
-                <button id="deleteAllFireCrazeButton" class="buttonDiv">
-                    <p class="special">Delete All FireCraze</p>
-                </button>
-                <button id="deleteAllShenviiButton" class="buttonDiv">
-                    <p class="special">Delete All sʜeɴvɪ✞∞</p>
-                </button>
-
-                <button id="deleteAllUnder100kButton" class="buttonDivClass">
-                    <p class="under100k">Delete All Mastery</p>
-                </button>
-                <button id="deleteAllUnfairButton" class="buttonDiv">
-                    <p class="under100k">Delete All Unfair</p>
-                </button>
-                <button id="deleteAllCursedMirageButton" class="buttonDiv">
-                    <p class="under100k">Delete All Cursed Mirage</p>
-                </button>
-                <button id="deleteAllCelestialDawnButton" class="buttonDiv">
-                    <p class="under100k">Delete All Celestial Dawn</p>
-                </button>
-                <button id="deleteAllFatesRequiemButton" class="buttonDiv">
-                    <p class="under100k">Delete All Fates Requiem</p>
-                </button>
-                <button id="deleteAllEonbreakButton" class="buttonDiv">
-                    <p class="under100k">Delete All Eonbreak</p>
-                </button>
-                <button id="deleteAllOvertureButton" class="buttonDiv">
-                    <p class="under100k">Delete All Overture</p>
-                </button>
-                <button id="deleteAllLightButton" class="buttonDiv">
-                    <p class="under100k">Delete All Light</p>
-                </button>
-                <button id="deleteAllUnnamedButton" class="buttonDiv">
-                    <p class="under100k">Delete All Unnamed</p>
-                </button>
-                <button id="deleteAllQbearButton" class="buttonDiv">
-                    <p class="under100k">Delete All Qbear</p>
-                </button>
-                
-                <button id="deleteAllBlodhestButton" class="buttonDiv">
-                    <p class="under100k">Delete All Blodhest</p>
-                </button>
-                <button id="deleteAllHarvButton" class="buttonDiv">
-                    <p class="under100k">Delete All HARV</p>
-                </button>
-                <button id="deleteAllTuonButton" class="buttonDiv">
-                    <p class="under100k">Delete All Tuon</p>
-                </button>
-                <button id="deleteAllDevilsHeartButton" class="buttonDiv">
-                    <p class="under100k">Delete All Devil's Heart</p>
-                </button>
-                <button id="deleteAllArcanePulseButton" class="buttonDiv">
-                    <p class="under100k">Delete All Arcane Pulse</p>
-                </button>
-
-                <button id="deleteAllUnder1mButton" class="buttonDivClass">
-                    <p class="under1mBtn">Delete All Supreme</p>
-                </button>
-                <button id="deleteAllImpeachedButton" class="buttonDiv">
-                    <p class="under1m">Delete All Impeached</p>
-                </button>
-                <button id="deleteAllCelestialChorusButton" class="buttonDiv">
-                    <p class="under1m">Delete All Celestial Chorus</p>
-                </button>
-                <button id="deleteAllX1staButton" class="buttonDiv">
-                    <p class="under1m">Delete All X1sta</p>
-                </button>
-
-                <button id="deleteAllSillyCarButton" class="buttonDiv">
-                    <p class="under10ms">Delete All Silly Car :3</p>
-                </button>
-                <button id="deleteAllGingerButton" class="buttonDiv">
-                    <p class="under10ms">Delete All Ginger</p>
-                </button>
-
-                <button id="deleteAllH1diButton" class="buttonDiv">
-                    <p class="under10m">Delete All H1di</p>
-                </button>
-
-                <button id="deleteAllEquinoxButton" class="buttonDiv">
-                    <p class="under10me">Delete All 『Equinox』</p>
-                </button>
+                    <section class="inventory-group inventory-group--supreme">
+                        <div class="inventory-group__header">
+                            <h4 class="inventory-group__title">Supreme Titles</h4>
+                            <button id="deleteAllUnder1mButton" class="inventory-group__clear" type="button">Clear Supreme</button>
+                        </div>
+                        <div class="inventory-group__grid">
+                            <button id="deleteAllImpeachedButton" class="inventory-delete-btn" type="button" title="Delete All Impeached">Impeached</button>
+                            <button id="deleteAllCelestialChorusButton" class="inventory-delete-btn" type="button" title="Delete All Celestial Chorus">Celestial Chorus</button>
+                            <button id="deleteAllX1staButton" class="inventory-delete-btn" type="button" title="Delete All X1sta">X1sta</button>
+                            <button id="deleteAllSillyCarButton" class="inventory-delete-btn" type="button" title="Delete All Silly Car :3">Silly Car :3</button>
+                            <button id="deleteAllGingerButton" class="inventory-delete-btn" type="button" title="Delete All Ginger">Ginger</button>
+                            <button id="deleteAllH1diButton" class="inventory-delete-btn" type="button" title="Delete All H1di">H1di</button>
+                            <button id="deleteAllEquinoxButton" class="inventory-delete-btn" type="button" title="Delete All 『Equinox』"><span class="under10me">『Equinox』</span></button>
+                        </div>
+                    </section>
+                </div>
 
                 <ul class="inv" id="inventoryList"></ul>
 


### PR DESCRIPTION
## Summary
- allow dragging the settings dialog from the full header bar while protecting the close button from initiating a drag
- cleanly reset the dialog position on drag start and update cursor feedback so grabbing state is obvious
- enable the settings content column to scroll by relaxing flex sizing constraints and preserving the grab cursor styling

## Testing
- not run (project has no automated tests)

------
https://chatgpt.com/codex/tasks/task_e_68d4dd9d677c8321a4f3a4bdc7d208db