### PR TITLE
Improve settings menu layout and scrolling

### DIFF
--- a/files/script.js
+++ b/files/script.js
@@ -10915,6 +10915,7 @@ scheduleAllCooldownButtons();
 document.addEventListener("DOMContentLoaded", () => {
   const settingsMenu = document.getElementById("settingsMenu");
   const settingsHeader = settingsMenu?.querySelector(".settings-header");
+  const settingsBody = settingsMenu?.querySelector(".settings-body");
   const headerStats = statsMenu.querySelector("h3");
   let isDraggingSettings = false;
   let isDraggingStats = false;
@@ -10949,6 +10950,21 @@ document.addEventListener("DOMContentLoaded", () => {
       offsetYStyle = event.clientY - statsMenu.offsetTop;
       headerStats.style.cursor = "grabbing";
     });
+  }
+
+  if (settingsMenu && settingsBody) {
+    settingsMenu.addEventListener(
+      "wheel",
+      (event) => {
+        if (settingsBody.contains(event.target)) {
+          return;
+        }
+
+        settingsBody.scrollTop += event.deltaY;
+        event.preventDefault();
+      },
+      { passive: false }
+    );
   }
 
   document.addEventListener("mousemove", (event) => {

--- a/files/style.css
+++ b/files/style.css
@@ -1015,6 +1015,8 @@ body {
     width: min(700px, calc(100vw - 32px));
     max-height: min(88vh, 700px);
     padding: 0;
+    display: flex;
+    flex-direction: column;
     background:
         linear-gradient(160deg, rgba(28,34,54,0.88), rgba(12,18,32,0.95)),
         url(backgrounds/rng_master.png);
@@ -1030,6 +1032,7 @@ body {
 .settings-panel {
     display: flex;
     flex-direction: column;
+    flex: 1 1 auto;
     height: 100%;
     min-height: 0;
 }
@@ -1072,15 +1075,34 @@ body {
 .settings-body {
     flex: 1;
     overflow-y: auto;
-    padding: 20px 22px 24px 22px;
+    padding: 20px 24px 28px 24px;
     display: grid;
     gap: 18px;
     grid-template-columns: minmax(0, 1fr);
+    grid-auto-flow: row dense;
     align-content: start;
     min-height: 0;
     scrollbar-gutter: stable both-edges;
+    scrollbar-width: thin;
+    scrollbar-color: rgba(120, 164, 255, 0.55) rgba(12, 18, 32, 0.35);
     overscroll-behavior: contain;
     touch-action: pan-y;
+    -webkit-overflow-scrolling: touch;
+}
+
+.settings-body::-webkit-scrollbar {
+    width: 10px;
+}
+
+.settings-body::-webkit-scrollbar-track {
+    background: rgba(12, 18, 32, 0.35);
+    border-radius: 999px;
+}
+
+.settings-body::-webkit-scrollbar-thumb {
+    background: linear-gradient(180deg, rgba(120, 164, 255, 0.75), rgba(74, 110, 190, 0.85));
+    border-radius: 999px;
+    border: 2px solid rgba(12, 18, 32, 0.35);
 }
 
 .settings-header.is-dragging {

--- a/index.html
+++ b/index.html
@@ -40,7 +40,7 @@
                 <button id="closeSettings" class="settings-close-btn" type="button">Close</button>
             </div>
             <div class="settings-body">
-                <section class="settings-section settings-section--full">
+                <section class="settings-section">
                     <h4 class="settings-section__title">Audio</h4>
                     <div class="settings-audio">
                         <label class="settings-audio__label" for="audioSlider">Master Volume</label>
@@ -54,7 +54,7 @@
                     </div>
                 </section>
 
-                <section class="settings-section settings-section--full">
+                <section class="settings-section">
                     <h4 class="settings-section__title">Data Management</h4>
                     <div class="settings-grid">
                         <button id="saveButton" class="settings-btn" type="button">Save Data</button>


### PR DESCRIPTION
## Summary
- allow the settings panel to forward wheel scrolling from its frame and smooth out touch scrolling
- reorganize the settings sections into a two-column layout while keeping the existing visuals intact
- refresh settings body padding and scrollbar styling to make the long menu easier to read

## Testing
- No automated tests were run (not provided)


------
https://chatgpt.com/codex/tasks/task_e_68d516f29b9083218ba23483129f1834