### PR TITLE
Improve inventory rarity styling and settings layout

### DIFF
--- a/files/script.js
+++ b/files/script.js
@@ -10991,6 +10991,22 @@ document.addEventListener("DOMContentLoaded", () => {
   });
 });
 
+document.addEventListener("DOMContentLoaded", () => {
+  document.querySelectorAll(".inventory-delete-btn").forEach((button) => {
+    if (button.childElementCount > 0) {
+      return;
+    }
+
+    const label = button.textContent.replace(/\s+/g, " ").trim();
+    if (!label) {
+      return;
+    }
+
+    button.dataset.label = label;
+    button.classList.add("inventory-delete-btn--overlay");
+  });
+});
+
 const settingsButton = document.getElementById("settingsButton");
 const achievementsButton = document.getElementById("achievementsButton");
 const achievementsMenu = document.getElementById("achievementsMenu");

--- a/files/style.css
+++ b/files/style.css
@@ -1076,11 +1076,9 @@ body {
     flex: 1;
     overflow-y: auto;
     padding: 20px 24px 28px 24px;
-    display: grid;
+    display: flex;
+    flex-direction: column;
     gap: 18px;
-    grid-template-columns: minmax(0, 1fr);
-    grid-auto-flow: row dense;
-    align-content: start;
     min-height: 0;
     scrollbar-gutter: stable both-edges;
     scrollbar-width: thin;
@@ -1088,6 +1086,13 @@ body {
     overscroll-behavior: contain;
     touch-action: pan-y;
     -webkit-overflow-scrolling: touch;
+}
+
+.settings-layout {
+    display: grid;
+    gap: 18px;
+    grid-template-columns: repeat(auto-fit, minmax(260px, 1fr));
+    align-content: start;
 }
 
 .settings-body::-webkit-scrollbar {
@@ -1121,7 +1126,7 @@ body {
 }
 
 .settings-section--full {
-    grid-column: 1 / -1;
+    width: 100%;
 }
 
 .settings-section__title {
@@ -1139,7 +1144,7 @@ body {
 }
 
 @media (min-width: 720px) {
-    .settings-body {
+    .settings-layout {
         grid-template-columns: repeat(2, minmax(0, 1fr));
     }
 }
@@ -3015,6 +3020,54 @@ body.griCutsceneBgImg {
   border-color: rgba(176, 210, 255, 0.45);
 }
 
+.inventory-delete-btn--overlay {
+  position: relative;
+  color: transparent;
+}
+
+.inventory-delete-btn--overlay::after {
+  content: attr(data-label);
+  position: absolute;
+  inset: 0;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  padding: 0 12px;
+  text-align: center;
+  font: inherit;
+  line-height: inherit;
+  letter-spacing: inherit;
+  white-space: normal;
+  word-break: keep-all;
+  pointer-events: none;
+  background: var(--inventory-text-gradient, linear-gradient(120deg, #e4ecff, #f9fbff));
+  background-size: var(--inventory-text-gradient-size, 100% 100%);
+  background-position: var(--inventory-text-gradient-position, 50% 50%);
+  -webkit-background-clip: text;
+  background-clip: text;
+  color: transparent;
+  transition: background 0.35s ease;
+  animation: var(--inventory-text-gradient-animation, none);
+}
+
+.inventory-delete-btn--overlay:hover::after {
+  background: var(--inventory-text-gradient-hover, var(--inventory-text-gradient, linear-gradient(120deg, #f1f5ff, #ffffff)));
+  background-size: var(--inventory-text-gradient-size, 100% 100%);
+  background-position: var(--inventory-text-gradient-position, 50% 50%);
+}
+
+@keyframes inventory-text-pan {
+  0% {
+    background-position: 0% 50%;
+  }
+  50% {
+    background-position: 100% 50%;
+  }
+  100% {
+    background-position: 0% 50%;
+  }
+}
+
 .inventory-group--basic {
   --group-bg-a: rgba(24, 46, 96, 0.72);
   --group-bg-b: rgba(12, 24, 48, 0.92);
@@ -3023,6 +3076,11 @@ body.griCutsceneBgImg {
 
 .inventory-group--basic .inventory-delete-btn {
   background: rgba(36, 58, 108, 0.78);
+}
+
+.inventory-group--basic .inventory-delete-btn--overlay {
+  --inventory-text-gradient: linear-gradient(130deg, #b7cbff, #f5f8ff);
+  --inventory-text-gradient-hover: linear-gradient(130deg, #d7e3ff, #ffffff);
 }
 
 .inventory-group--decent {
@@ -3035,10 +3093,20 @@ body.griCutsceneBgImg {
   background: rgba(24, 66, 66, 0.76);
 }
 
+.inventory-group--decent .inventory-delete-btn--overlay {
+  --inventory-text-gradient: linear-gradient(135deg, #54f7e2, #9df6ff);
+  --inventory-text-gradient-hover: linear-gradient(135deg, #7fffee, #d4fbff);
+}
+
 .inventory-group--grand {
   --group-bg-a: rgba(34, 68, 38, 0.72);
   --group-bg-b: rgba(16, 28, 24, 0.92);
   --group-border: rgba(138, 236, 160, 0.28);
+}
+
+.inventory-group--grand .inventory-delete-btn--overlay {
+  --inventory-text-gradient: linear-gradient(140deg, #9dffb5, #4be690, #e2ffe8);
+  --inventory-text-gradient-hover: linear-gradient(140deg, #c1ffd0, #6dffad, #ffffff);
 }
 
 .inventory-group--events {
@@ -3059,10 +3127,24 @@ body.griCutsceneBgImg {
   --group-border: rgba(255, 172, 140, 0.3);
 }
 
+.inventory-group--mastery .inventory-delete-btn--overlay {
+  --inventory-text-gradient: radial-gradient(circle at 20% 20%, #ffdfd3, #ff7ab8 45%, #ffc764 85%);
+  --inventory-text-gradient-hover: radial-gradient(circle at 20% 20%, #ffe8e0, #ff8ec6 45%, #ffd27d 85%);
+  --inventory-text-gradient-size: 220% 220%;
+  --inventory-text-gradient-animation: inventory-text-pan 7s ease-in-out infinite;
+}
+
 .inventory-group--supreme {
   --group-bg-a: rgba(68, 28, 74, 0.72);
   --group-bg-b: rgba(28, 12, 36, 0.92);
   --group-border: rgba(224, 156, 255, 0.32);
+}
+
+.inventory-group--supreme .inventory-delete-btn--overlay {
+  --inventory-text-gradient: radial-gradient(circle at 30% 20%, #bbf7ff, #8c5bff 45%, #ffd67a 80%);
+  --inventory-text-gradient-hover: radial-gradient(circle at 30% 20%, #d6fbff, #a57cff 45%, #ffe49c 80%);
+  --inventory-text-gradient-size: 250% 250%;
+  --inventory-text-gradient-animation: inventory-text-pan 6s ease-in-out infinite;
 }
 
 #toggleInventoryBtn {

--- a/index.html
+++ b/index.html
@@ -40,47 +40,49 @@
                 <button id="closeSettings" class="settings-close-btn" type="button">Close</button>
             </div>
             <div class="settings-body">
-                <section class="settings-section">
-                    <h4 class="settings-section__title">Audio</h4>
-                    <div class="settings-audio">
-                        <label class="settings-audio__label" for="audioSlider">Master Volume</label>
-                        <div class="settings-audio__controls">
-                            <div class="settings-audio__slider">
-                                <input type="range" id="audioSlider" min="0" max="1" step="0.01" value="1">
-                                <span id="audioSliderValue" class="settings-audio__value">100%</span>
+                <div class="settings-layout">
+                    <section class="settings-section">
+                        <h4 class="settings-section__title">Audio</h4>
+                        <div class="settings-audio">
+                            <label class="settings-audio__label" for="audioSlider">Master Volume</label>
+                            <div class="settings-audio__controls">
+                                <div class="settings-audio__slider">
+                                    <input type="range" id="audioSlider" min="0" max="1" step="0.01" value="1">
+                                    <span id="audioSliderValue" class="settings-audio__value">100%</span>
+                                </div>
+                                <button id="muteButton" class="settings-btn settings-btn--ghost" type="button">Mute</button>
                             </div>
-                            <button id="muteButton" class="settings-btn settings-btn--ghost" type="button">Mute</button>
                         </div>
-                    </div>
-                </section>
+                    </section>
 
-                <section class="settings-section">
-                    <h4 class="settings-section__title">Data Management</h4>
-                    <div class="settings-grid">
-                        <button id="saveButton" class="settings-btn" type="button">Save Data</button>
-                        <button id="importButton" class="settings-btn" type="button">Import Data</button>
-                        <button id="resetDataButton" class="settings-btn settings-btn--danger" type="button">Reset Data</button>
-                    </div>
-                    <p id="status" class="statusImport"></p>
-                </section>
+                    <section class="settings-section">
+                        <h4 class="settings-section__title">Data Management</h4>
+                        <div class="settings-grid">
+                            <button id="saveButton" class="settings-btn" type="button">Save Data</button>
+                            <button id="importButton" class="settings-btn" type="button">Import Data</button>
+                            <button id="resetDataButton" class="settings-btn settings-btn--danger" type="button">Reset Data</button>
+                        </div>
+                        <p id="status" class="statusImport"></p>
+                    </section>
 
-                <section class="settings-section">
-                    <h4 class="settings-section__title">Interface</h4>
-                    <div class="settings-grid">
-                        <button id="toggleRollDisplayBtn" class="settings-btn settings-btn--ghost" type="button">Hide Roll &amp; Display</button>
-                        <button id="toggleRollHistoryBtn" class="settings-btn settings-btn--ghost" type="button">Hide Roll History</button>
-                    </div>
-                </section>
+                    <section class="settings-section">
+                        <h4 class="settings-section__title">Interface</h4>
+                        <div class="settings-grid">
+                            <button id="toggleRollDisplayBtn" class="settings-btn settings-btn--ghost" type="button">Hide Roll &amp; Display</button>
+                            <button id="toggleRollHistoryBtn" class="settings-btn settings-btn--ghost" type="button">Hide Roll History</button>
+                        </div>
+                    </section>
 
-                <section class="settings-section">
-                    <h4 class="settings-section__title">Cutscene Skip</h4>
-                    <div id="rarityChecklistC" class="settings-chip-group">
-                        <button id="toggleCutscene1K" class="cutsceneSkipBtb" type="button"><span id="1KTxt" class="under1kT">Skip Decent Cutscenes</span></button>
-                        <button id="toggleCutscene10K" class="cutsceneSkipBtb" type="button"><span id="10KTxt" class="under10kT">Skip Grand Cutscenes</span></button>
-                        <button id="toggleCutscene100K" class="cutsceneSkipBtb" type="button"><span id="100KTxt" class="under100k">Skip Mastery Cutscenes</span></button>
-                        <button id="toggleCutscene1M" class="cutsceneSkipBtb" type="button"><span id="1MTxt" class="under1mBtn">Skip Supreme Cutscenes</span></button>
-                    </div>
-                </section>
+                    <section class="settings-section">
+                        <h4 class="settings-section__title">Cutscene Skip</h4>
+                        <div id="rarityChecklistC" class="settings-chip-group">
+                            <button id="toggleCutscene1K" class="cutsceneSkipBtb" type="button"><span id="1KTxt" class="under1kT">Skip Decent Cutscenes</span></button>
+                            <button id="toggleCutscene10K" class="cutsceneSkipBtb" type="button"><span id="10KTxt" class="under10kT">Skip Grand Cutscenes</span></button>
+                            <button id="toggleCutscene100K" class="cutsceneSkipBtb" type="button"><span id="100KTxt" class="under100k">Skip Mastery Cutscenes</span></button>
+                            <button id="toggleCutscene1M" class="cutsceneSkipBtb" type="button"><span id="1MTxt" class="under1mBtn">Skip Supreme Cutscenes</span></button>
+                        </div>
+                    </section>
+                </div>
 
                 <section class="settings-section settings-section--full">
                     <h4 class="settings-section__title">Auto Delete Rarity</h4>


### PR DESCRIPTION
## Summary
- restructure the settings menu content into a responsive grid so sections fit within the modal without clipping
- overlay rarity delete buttons with dynamic gradient text that varies per rarity, including animated palettes for mastery and supreme titles
- add runtime preparation to preserve button labels while applying the new gradient overlays only when needed

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68d5197d7bd08321a70e43244cf75d50