### PR TITLE
Rework achievements menu layout

### DIFF
--- a/files/script.js
+++ b/files/script.js
@@ -10915,11 +10915,17 @@ document.addEventListener("DOMContentLoaded", () => {
   const settingsMenu = document.getElementById("settingsMenu");
   const settingsHeader = settingsMenu?.querySelector(".settings-header");
   const settingsBody = settingsMenu?.querySelector(".settings-body");
+  const achievementsMenu = document.getElementById("achievementsMenu");
+  const achievementsHeader = achievementsMenu?.querySelector(".achievements-header");
+  const achievementsBody = achievementsMenu?.querySelector(".achievements-body");
   const headerStats = statsMenu.querySelector("h3");
   let isDraggingSettings = false;
+  let isDraggingAchievements = false;
   let isDraggingStats = false;
   let offsetX = 0;
   let offsetY = 0;
+  let offsetXAchievements = 0;
+  let offsetYAchievements = 0;
   let offsetXStyle = 0;
   let offsetYStyle = 0;
 
@@ -10938,6 +10944,25 @@ document.addEventListener("DOMContentLoaded", () => {
       offsetY = event.clientY - rect.top;
       isDraggingSettings = true;
       settingsHeader.classList.add("is-dragging");
+      event.preventDefault();
+    });
+  }
+
+  if (achievementsHeader) {
+    achievementsHeader.addEventListener("mousedown", (event) => {
+      if (event.button !== 0 || event.target.closest(".achievements-close-btn")) {
+        return;
+      }
+
+      const rect = achievementsMenu.getBoundingClientRect();
+      achievementsMenu.style.left = `${rect.left}px`;
+      achievementsMenu.style.top = `${rect.top}px`;
+      achievementsMenu.style.transform = "none";
+
+      offsetXAchievements = event.clientX - rect.left;
+      offsetYAchievements = event.clientY - rect.top;
+      isDraggingAchievements = true;
+      achievementsHeader.classList.add("is-dragging");
       event.preventDefault();
     });
   }
@@ -10966,10 +10991,30 @@ document.addEventListener("DOMContentLoaded", () => {
     );
   }
 
+  if (achievementsMenu && achievementsBody) {
+    achievementsMenu.addEventListener(
+      "wheel",
+      (event) => {
+        if (achievementsBody.contains(event.target)) {
+          return;
+        }
+
+        achievementsBody.scrollTop += event.deltaY;
+        event.preventDefault();
+      },
+      { passive: false }
+    );
+  }
+
   document.addEventListener("mousemove", (event) => {
     if (isDraggingSettings) {
       settingsMenu.style.left = `${event.clientX - offsetX}px`;
       settingsMenu.style.top = `${event.clientY - offsetY}px`;
+    }
+
+    if (isDraggingAchievements) {
+      achievementsMenu.style.left = `${event.clientX - offsetXAchievements}px`;
+      achievementsMenu.style.top = `${event.clientY - offsetYAchievements}px`;
     }
 
     if (isDraggingStats) {
@@ -10982,6 +11027,11 @@ document.addEventListener("DOMContentLoaded", () => {
     if (isDraggingSettings) {
       isDraggingSettings = false;
       settingsHeader?.classList.remove("is-dragging");
+    }
+
+    if (isDraggingAchievements) {
+      isDraggingAchievements = false;
+      achievementsHeader?.classList.remove("is-dragging");
     }
 
     if (isDraggingStats) {
@@ -11032,6 +11082,10 @@ closeSettings.addEventListener("click", () => {
 
 achievementsButton.addEventListener("click", () => {
   achievementsMenu.style.display = "block";
+  const achievementsBodyElement = achievementsMenu.querySelector(".achievements-body");
+  if (achievementsBodyElement) {
+    achievementsBodyElement.scrollTop = 0;
+  }
 });
 
 closeAchievements.addEventListener("click", () => {

--- a/files/style.css
+++ b/files/style.css
@@ -1315,18 +1315,6 @@ body {
     cursor: not-allowed;
 }
 
-.achievementsBtns {
-    display: inline-block;
-    padding: 10px 15px;
-    margin: 10px 0;
-    font-size: 1rem;
-    font-weight: bold;
-    border: none;
-    border-radius: 5px;
-    cursor: pointer;
-    transition: all 0.3s ease-in-out;
-}
-
 .statsBtns {
     display: inline-block;
     padding: 10px 15px;
@@ -4092,237 +4080,114 @@ body.griCutsceneBgImg {
 }
 
 .achievement-grid {
-    display: flex;
-    flex-wrap: wrap;
-    justify-content: center;
-    gap: 10px;
-    background: #222;
-    padding: 10px;
-    border-radius: 8px;
-    align-items: center;
-    margin: 10px;
-    margin-bottom: 5px;
+    display: grid;
+    gap: 12px;
+    grid-template-columns: repeat(auto-fit, minmax(180px, 1fr));
+    margin: 0;
+    padding: 0;
+    list-style: none;
 }
 
-.achievement-item {
+.achievement-grid + .achievement-grid {
+    margin-top: 10px;
+}
+
+.achievement-item,
+.achievement-itemT,
+.achievement-itemC,
+.achievement-itemE,
+.achievement-itemSum {
     position: relative;
-    padding: 20px;
+    padding: 16px 14px;
     text-align: center;
-    border-radius: 5px;
-    font-weight: bold;
-    font-size: 13px;
-    color: white;
-    background: #444;
-    flex: 0 0 calc(25% - 10px);
+    border-radius: 12px;
+    font-weight: 600;
+    font-size: 0.95rem;
+    color: #f3f6ff;
+    background: linear-gradient(155deg, rgba(40, 56, 94, 0.82), rgba(18, 28, 52, 0.88));
+    border: 1px solid rgba(130, 176, 255, 0.22);
+    box-shadow: 0 14px 32px rgba(0, 0, 0, 0.35);
     cursor: pointer;
-    z-index: 9999999999;
+    transition: transform 0.2s ease, background 0.2s ease, border-color 0.2s ease;
+    z-index: 1;
+    line-height: 1.35;
+    backdrop-filter: blur(4px);
+    text-wrap: balance;
+    word-break: break-word;
+}
+
+.achievement-itemT,
+.achievement-itemC,
+.achievement-itemE,
+.achievement-itemSum {
+    font-size: 0.9rem;
+    padding-left: 12px;
+    padding-right: 12px;
+}
+
+.achievement-item:hover,
+.achievement-itemT:hover,
+.achievement-itemC:hover,
+.achievement-itemE:hover,
+.achievement-itemSum:hover {
+    transform: translateY(-2px);
+    background: linear-gradient(155deg, rgba(62, 86, 138, 0.9), rgba(26, 36, 64, 0.95));
+    border-color: rgba(167, 205, 255, 0.4);
 }
 
 .achievement-item:hover::after {
     content: "Roll " attr(data-roll) " rolls to unlock this achievement";
-    position: absolute;
-    bottom: 100%;
-    left: 50%;
-    transform: translateX(-50%);
-    background: rgba(0, 0, 0, 0.8);
-    color: #fff;
-    padding: 10px;
-    border-radius: 5px;
-    white-space: nowrap;
-    pointer-events: none;
-    margin-bottom: 5px;
-    font-size: 12px;
-    z-index: 999999999999;
-}
-
-.achievement-item:hover::before {
-    content: "";
-    position: absolute;
-    bottom: 100%;
-    left: 50%;
-    transform: translateX(-50%);
-    border-width: 5px;
-    border-style: solid;
-    border-color: transparent transparent rgba(0, 0, 0, 0.8) transparent;
-    z-index: 999999999999;
-}
-
-.achievement-itemT {
-    position: relative;
-    padding: 20px;
-    padding-left: 5px;
-    padding-right: 5px;
-    text-align: center;
-    border-radius: 5px;
-    font-weight: bold;
-    font-size: 15px;
-    color: white;
-    background: #444;
-    flex: 0 0 calc(25% - 10px);
-    cursor: pointer;
-    z-index: 1;
 }
 
 .achievement-itemT:hover::after {
     content: "Play " attr(data-time) " to unlock this achievement";
-    position: absolute;
-    bottom: 100%;
-    left: 50%;
-    transform: translateX(-50%);
-    background: rgba(0, 0, 0, 0.8);
-    color: #fff;
-    padding: 10px;
-    border-radius: 5px;
-    white-space: nowrap;
-    pointer-events: none;
-    margin-bottom: 5px;
-    font-size: 12px;
-    z-index: 999999999;
-}
-
-.achievement-itemT:hover::before {
-    content: "";
-    position: absolute;
-    bottom: 100%;
-    left: 50%;
-    transform: translateX(-50%);
-    border-width: 5px;
-    border-style: solid;
-    border-color: transparent transparent rgba(0, 0, 0, 0.8) transparent;
-    z-index: 999999999999;
-}
-
-.achievement-itemC {
-    position: relative;
-    padding: 20px;
-    padding-left: 5px;
-    padding-right: 5px;
-    text-align: center;
-    border-radius: 5px;
-    font-weight: bold;
-    font-size: 15px;
-    color: white;
-    background: #444;
-    flex: 0 0 calc(25% - 10px);
-    cursor: pointer;
-    z-index: 1;
 }
 
 .achievement-itemC:hover::after {
     content: "Collect " attr(data-achievement) " achievements to unlock this achievement";
-    position: absolute;
-    bottom: 100%;
-    left: 50%;
-    transform: translateX(-50%);
-    background: rgba(0, 0, 0, 0.8);
-    color: #fff;
-    padding: 10px;
-    border-radius: 5px;
-    white-space: nowrap;
-    pointer-events: none;
-    margin-bottom: 5px;
-    font-size: 12px;
-    z-index: 999999999;
 }
 
-.achievement-itemC:hover::before {
-    content: "";
-    position: absolute;
-    bottom: 100%;
-    left: 50%;
-    transform: translateX(-50%);
-    border-width: 5px;
-    border-style: solid;
-    border-color: transparent transparent rgba(0, 0, 0, 0.8) transparent;
-    z-index: 999999999999;
-}
-
-.achievement-itemE {
-    position: relative;
-    padding: 20px;
-    padding-left: 5px;
-    padding-right: 5px;
-    text-align: center;
-    border-radius: 5px;
-    font-weight: bold;
-    font-size: 15px;
-    color: white;
-    background: #444;
-    flex: 0 0 calc(25% - 10px);
-    cursor: pointer;
-    z-index: 1;
-}
-
-.achievement-itemE:hover::after {
-    content: "Play in " attr(data-time) " to unlock this achievement";
-    position: absolute;
-    bottom: 100%;
-    left: 50%;
-    transform: translateX(-50%);
-    background: rgba(0, 0, 0, 0.8);
-    color: #fff;
-    padding: 10px;
-    border-radius: 5px;
-    white-space: nowrap;
-    pointer-events: none;
-    margin-bottom: 5px;
-    font-size: 12px;
-    z-index: 999999999;
-}
-
-.achievement-itemE:hover::before {
-    content: "";
-    position: absolute;
-    bottom: 100%;
-    left: 50%;
-    transform: translateX(-50%);
-    border-width: 5px;
-    border-style: solid;
-    border-color: transparent transparent rgba(0, 0, 0, 0.8) transparent;
-    z-index: 999999999999;
-}
-
-.achievement-itemSum {
-    position: relative;
-    padding: 20px;
-    text-align: center;
-    border-radius: 5px;
-    font-weight: bold;
-    font-size: 13px;
-    color: white;
-    background: #444;
-    flex: 0 0 calc(25% - 10px);
-    cursor: pointer;
-    z-index: 9999999999;
-}
-
+.achievement-itemE:hover::after,
 .achievement-itemSum:hover::after {
     content: "Play in " attr(data-time) " to unlock this achievement";
+}
+
+.achievement-item:hover::after,
+.achievement-itemT:hover::after,
+.achievement-itemC:hover::after,
+.achievement-itemE:hover::after,
+.achievement-itemSum:hover::after {
     position: absolute;
     bottom: 100%;
     left: 50%;
     transform: translateX(-50%);
-    background: rgba(0, 0, 0, 0.8);
-    color: #fff;
-    padding: 10px;
-    border-radius: 5px;
+    background: rgba(6, 10, 22, 0.94);
+    color: #f4f7ff;
+    padding: 10px 12px;
+    border-radius: 8px;
+    border: 1px solid rgba(130, 176, 255, 0.35);
     white-space: nowrap;
     pointer-events: none;
-    margin-bottom: 5px;
-    font-size: 12px;
-    z-index: 999999999999;
+    margin-bottom: 8px;
+    font-size: 0.78rem;
+    box-shadow: 0 16px 32px rgba(0, 0, 0, 0.35);
+    z-index: 5;
 }
 
+.achievement-item:hover::before,
+.achievement-itemT:hover::before,
+.achievement-itemC:hover::before,
+.achievement-itemE:hover::before,
 .achievement-itemSum:hover::before {
     content: "";
     position: absolute;
     bottom: 100%;
     left: 50%;
-    transform: translateX(-50%);
-    border-width: 5px;
+    transform: translate(-50%, -3px);
+    border-width: 6px;
     border-style: solid;
-    border-color: transparent transparent rgba(0, 0, 0, 0.8) transparent;
-    z-index: 999999999999;
+    border-color: transparent transparent rgba(6, 10, 22, 0.94) transparent;
+    z-index: 4;
 }
 
 #achievementsMenu {
@@ -4330,52 +4195,168 @@ body.griCutsceneBgImg {
     top: 50%;
     left: 50%;
     transform: translate(-50%, -50%);
-    width: 80%;
-    max-height: 70vh;
-    padding: 20px;
-    background: url(backgrounds/rng_master.png);
-    border-radius: 10px;
-    border-style: groove;
-    box-shadow: 0 4px 10px rgba(0, 0, 0, 0.5);
-    z-index: 90000000;
-    color: white;
-    font-family: 'Arial', sans-serif;
-    text-align: center;
+    width: min(760px, calc(100vw - 32px));
+    max-height: min(88vh, 720px);
+    padding: 0;
     display: flex;
     flex-direction: column;
+    color: #f1f5ff;
+    z-index: 10000000;
+}
+
+.achievements-panel {
+    display: flex;
+    flex-direction: column;
+    flex: 1 1 auto;
+    background:
+        linear-gradient(160deg, rgba(28, 34, 54, 0.92), rgba(12, 18, 32, 0.96)),
+        url(backgrounds/rng_master.png);
+    background-size: cover;
+    border-radius: 18px;
+    border: 1px solid rgba(120, 164, 255, 0.24);
+    box-shadow: 0 24px 60px rgba(0, 0, 0, 0.55);
+    overflow: hidden;
+    min-height: 0;
+}
+
+.achievements-header {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    gap: 16px;
+    padding: 18px 22px 14px 22px;
+    border-bottom: 1px solid rgba(120, 164, 255, 0.16);
+    background: rgba(10, 14, 26, 0.65);
+    backdrop-filter: blur(12px);
+    cursor: grab;
+    user-select: none;
+}
+
+.achievements-header .dragTxt {
+    opacity: 0.85;
+    font-size: 1.25rem;
+    font-weight: 600;
+    padding: 0;
+}
+
+.achievements-header.is-dragging {
+    cursor: grabbing;
+}
+
+.achievements-close-btn {
+    border: 1px solid rgba(255, 255, 255, 0.12);
+    border-radius: 12px;
+    background: rgba(40, 62, 110, 0.55);
+    color: #f4f7ff;
+    padding: 10px 14px;
+    font-size: 0.95rem;
+    font-weight: 600;
+    text-align: center;
+    transition: transform 0.2s ease, background 0.2s ease, border-color 0.2s ease;
+}
+
+.achievements-close-btn:hover {
+    transform: translateY(-1px);
+    background: rgba(76, 104, 163, 0.75);
+    border-color: rgba(167, 200, 255, 0.4);
+}
+
+.achievements-close-btn:active {
+    transform: translateY(0);
+}
+
+.achievements-body {
+    flex: 1;
+    overflow-y: auto;
+    padding: 20px 24px 28px 24px;
+    display: flex;
+    flex-direction: column;
+    gap: 18px;
+    min-height: 0;
+    scrollbar-gutter: stable both-edges;
+    scrollbar-width: thin;
+    scrollbar-color: rgba(120, 164, 255, 0.55) rgba(12, 18, 32, 0.35);
+    overscroll-behavior: contain;
+    touch-action: pan-y;
+    -webkit-overflow-scrolling: touch;
+}
+
+.achievements-body::-webkit-scrollbar {
+    width: 10px;
+}
+
+.achievements-body::-webkit-scrollbar-track {
+    background: rgba(12, 18, 32, 0.35);
+    border-radius: 999px;
+}
+
+.achievements-body::-webkit-scrollbar-thumb {
+    background: linear-gradient(180deg, rgba(120, 164, 255, 0.75), rgba(74, 110, 190, 0.85));
+    border-radius: 999px;
+    border: 2px solid rgba(12, 18, 32, 0.35);
+}
+
+.achievements-section {
+    background: rgba(15, 22, 38, 0.78);
+    border: 1px solid rgba(120, 164, 255, 0.14);
+    border-radius: 14px;
+    padding: 18px 20px;
+    display: flex;
+    flex-direction: column;
+    gap: 16px;
+}
+
+.achievements-section__title {
+    font-size: 1.05rem;
+    font-weight: 600;
+    margin: 0;
+    color: color-mix(in srgb, #c8d8ff 82%, #fff 18%);
+}
+
+.achievements-section__subtitle {
+    margin: 0;
+    font-size: 0.78rem;
+    letter-spacing: 0.08em;
+    text-transform: uppercase;
+    color: rgba(199, 215, 255, 0.75);
+}
+
+.achievements-subsection {
+    display: flex;
+    flex-direction: column;
+    gap: 8px;
 }
 
 .achievement-list {
-    flex-grow: 1;
-    max-height: 50vh;
-    overflow-y: auto;
-    padding: 10px;
-    margin-bottom: 10px;
+    display: contents;
 }
 
-.achievement-list::-webkit-scrollbar {
-    width: 8px;
+@media (max-width: 720px) {
+    #achievementsMenu {
+        width: min(640px, calc(100vw - 24px));
+        max-height: calc(100vh - 32px);
+    }
 }
 
-.achievement-list::-webkit-scrollbar-thumb {
-    background: rgba(255, 255, 255, 0.5);
-    border-radius: 4px;
+@media (max-width: 540px) {
+    #achievementsMenu {
+        left: 50%;
+        top: 12px;
+        transform: translate(-50%, 0);
+        width: calc(100vw - 20px);
+        height: calc(100vh - 24px);
+        max-height: none;
+    }
+
+    .achievements-panel {
+        height: 100%;
+    }
 }
 
-.achievement-list::-webkit-scrollbar-track {
-    background: rgba(0, 0, 0, 0.3);
-    border-radius: 4px;
-}
-
-#closeAchievements {
-    margin-top: auto;
-    padding: 10px 20px;
-    background: rgba(255, 0, 0, 0.8);
-    border: none;
-    color: white;
-    font-size: 16px;
-    cursor: pointer;
-    border-radius: 5px;
+@media (max-width: 640px) {
+    .achievement-grid {
+        grid-template-columns: repeat(auto-fit, minmax(150px, 1fr));
+    }
 }
 
 #closeAchievements:hover {

--- a/index.html
+++ b/index.html
@@ -115,55 +115,80 @@
     </div>
 
     <div id="achievementsMenu" class="achievements-menu" style="display: none;">
-        <div class="achievement-list">
-            <div class="achievement-grid">
-                <div class="achievement-item" data-roll="100" data-name="I think I like this">I think I like this</div>
-                <div class="achievement-item" data-roll="1,000" data-name="This is getting serious">This is getting serious</div>
-                <div class="achievement-item" data-roll="5,000" data-name="I'm the Roll Master">I'm the Roll Master</div>
-                <div class="achievement-item" data-roll="10,000" data-name="It's over 9000!!">It's over 9000!!</div>
-                <div class="achievement-item" data-roll="25,000" data-name="When will you stop?">When will you stop?</div>
-                <div class="achievement-item" data-roll="30,303" data-name="No Unnamed?">No Unnamed?</div>
-                <div class="achievement-item" data-roll="50,000" data-name="Beyond Luck">Beyond Luck</div>
-                <div class="achievement-item" data-roll="100,000" data-name="Rolling machine">Rolling machine</div>
-                <div class="achievement-item" data-roll="250,000" data-name="Your PC must be burning">Your PC must be burning</div>
-                <div class="achievement-item" data-roll="500,000" data-name="Half a million!1!!1">Half a million!1!!1</div>
-                <div class="achievement-item" data-roll="1,000,000" data-name="One, Two.. ..One Million!">One, Two.. ..One Million!</div>
-                <div class="achievement-item" data-roll="10,000,000" data-name="No H1di?">No H1di?</div>
-                <div class="achievement-item" data-roll="25,000,000" data-name="Are you really doing this?">Are you really doing this?</div>
-                <div class="achievement-item" data-roll="50,000,000" data-name="You have no limits...">You have no limits...</div>
-                <div class="achievement-item" data-roll="100,000,000" data-name="WHAT HAVE YOU DONE">WHAT HAVE YOU DONE</div>
-                <div class="achievement-item" data-roll="1,000,000,000" data-name="AHHHHHHHHHHH">AHHHHHHHHHHH</div>
+        <div class="achievements-panel">
+            <div class="achievements-header">
+                <h3 class="dragTxt">Achievements</h3>
+                <button id="closeAchievements" class="achievements-close-btn" type="button">Close</button>
             </div>
-            <div class="achievement-grid">
-                <div class="achievement-itemT" data-time="the game" data-name="Just the beginning">Just the beginning</div>
-                <div class="achievement-itemT" data-time="one hour" data-name="This doesn't add up">This doesn't add up</div>
-                <div class="achievement-itemT" data-time="two hours" data-name="When does it end...">When does it end...</div>
-                <div class="achievement-itemT" data-time="10 hours" data-name="I swear I'm not addicted...">I swear I'm not addicted...</div>
-                <div class="achievement-itemT" data-time="one day" data-name="Grass? What's that?">Grass? What's that?</div>
-                <div class="achievement-itemT" data-time="two days" data-name="Unnamed's RNG biggest fan">Unnamed's RNG biggest fan</div>
-                <div class="achievement-itemT" data-time="one week" data-name="RNG is life!">RNG is life!</div>
-                <div class="achievement-itemT" data-time="two weeks" data-name="I. CAN'T. STOP">I. CAN'T. STOP</div>
-                <div class="achievement-itemT" data-time="a month" data-name="No Lifer">No Lifer</div>
-                <div class="achievement-itemT" data-time="two months" data-name="Are you okay?">Are you okay?</div>
-                <div class="achievement-itemT" data-time="six months" data-name="You are a True No Lifer">You are a True No Lifer</div>
-                <div class="achievement-itemT" data-time="a year" data-name="No one's getting this legit">No one's getting this legit</div>
-            </div>
+            <div class="achievements-body achievement-list">
+                <section class="achievements-section">
+                    <h4 class="achievements-section__title">Roll Milestones</h4>
+                    <div class="achievement-grid">
+                        <div class="achievement-item" data-roll="100" data-name="I think I like this">I think I like this</div>
+                        <div class="achievement-item" data-roll="1,000" data-name="This is getting serious">This is getting serious</div>
+                        <div class="achievement-item" data-roll="5,000" data-name="I'm the Roll Master">I'm the Roll Master</div>
+                        <div class="achievement-item" data-roll="10,000" data-name="It's over 9000!!">It's over 9000!!</div>
+                        <div class="achievement-item" data-roll="25,000" data-name="When will you stop?">When will you stop?</div>
+                        <div class="achievement-item" data-roll="30,303" data-name="No Unnamed?">No Unnamed?</div>
+                        <div class="achievement-item" data-roll="50,000" data-name="Beyond Luck">Beyond Luck</div>
+                        <div class="achievement-item" data-roll="100,000" data-name="Rolling machine">Rolling machine</div>
+                        <div class="achievement-item" data-roll="250,000" data-name="Your PC must be burning">Your PC must be burning</div>
+                        <div class="achievement-item" data-roll="500,000" data-name="Half a million!1!!1">Half a million!1!!1</div>
+                        <div class="achievement-item" data-roll="1,000,000" data-name="One, Two.. ..One Million!">One, Two.. ..One Million!</div>
+                        <div class="achievement-item" data-roll="10,000,000" data-name="No H1di?">No H1di?</div>
+                        <div class="achievement-item" data-roll="25,000,000" data-name="Are you really doing this?">Are you really doing this?</div>
+                        <div class="achievement-item" data-roll="50,000,000" data-name="You have no limits...">You have no limits...</div>
+                        <div class="achievement-item" data-roll="100,000,000" data-name="WHAT HAVE YOU DONE">WHAT HAVE YOU DONE</div>
+                        <div class="achievement-item" data-roll="1,000,000,000" data-name="AHHHHHHHHHHH">AHHHHHHHHHHH</div>
+                    </div>
+                </section>
 
-            <div class="achievement-grid">
-                <div class="achievement-itemC" data-achievement="5" data-name="Achievement Collector">Achievement Collector</div>
-                <div class="achievement-itemC" data-achievement="10" data-name="Achievement Hoarder">Achievement Hoarder</div>
-                <div class="achievement-itemC" data-achievement="20" data-name="Achievement Addict">Achievement Addict</div>
-                <div class="achievement-itemC" data-achievement="33" data-name="Achievement God">Achievement God</div>
-                <div class="achievement-itemC" data-achievement="50" data-name="T̶h̶e̶ ̶U̶l̶t̶i̶m̶a̶t̶e̶ ̶C̶o̶l̶l̶e̶c̶t̶o̶r̶">T̶h̶e̶ ̶U̶l̶t̶i̶m̶a̶t̶e̶ ̶C̶o̶l̶l̶e̶c̶t̶o̶r̶<br>(not obtainable)</div>
-            </div>
+                <section class="achievements-section">
+                    <h4 class="achievements-section__title">Playtime Goals</h4>
+                    <div class="achievement-grid">
+                        <div class="achievement-itemT" data-time="the game" data-name="Just the beginning">Just the beginning</div>
+                        <div class="achievement-itemT" data-time="one hour" data-name="This doesn't add up">This doesn't add up</div>
+                        <div class="achievement-itemT" data-time="two hours" data-name="When does it end...">When does it end...</div>
+                        <div class="achievement-itemT" data-time="10 hours" data-name="I swear I'm not addicted...">I swear I'm not addicted...</div>
+                        <div class="achievement-itemT" data-time="one day" data-name="Grass? What's that?">Grass? What's that?</div>
+                        <div class="achievement-itemT" data-time="two days" data-name="Unnamed's RNG biggest fan">Unnamed's RNG biggest fan</div>
+                        <div class="achievement-itemT" data-time="one week" data-name="RNG is life!">RNG is life!</div>
+                        <div class="achievement-itemT" data-time="two weeks" data-name="I. CAN'T. STOP">I. CAN'T. STOP</div>
+                        <div class="achievement-itemT" data-time="a month" data-name="No Lifer">No Lifer</div>
+                        <div class="achievement-itemT" data-time="two months" data-name="Are you okay?">Are you okay?</div>
+                        <div class="achievement-itemT" data-time="six months" data-name="You are a True No Lifer">You are a True No Lifer</div>
+                        <div class="achievement-itemT" data-time="a year" data-name="No one's getting this legit">No one's getting this legit</div>
+                    </div>
+                </section>
 
-            <div class="achievement-grid">
-                <div class="achievement-itemE" data-time="the Easter Event" data-name="Happy Easter!">Happy Easter!</div>
-                <div class="achievement-itemSum" data-time="the Summer Event" data-name="Happy Summer!">Happy Summer!</div>
+                <section class="achievements-section">
+                    <h4 class="achievements-section__title">Collection Challenges</h4>
+                    <div class="achievement-grid">
+                        <div class="achievement-itemC" data-achievement="5" data-name="Achievement Collector">Achievement Collector</div>
+                        <div class="achievement-itemC" data-achievement="10" data-name="Achievement Hoarder">Achievement Hoarder</div>
+                        <div class="achievement-itemC" data-achievement="20" data-name="Achievement Addict">Achievement Addict</div>
+                        <div class="achievement-itemC" data-achievement="33" data-name="Achievement God">Achievement God</div>
+                        <div class="achievement-itemC" data-achievement="50" data-name="T̶h̶e̶ ̶U̶l̶t̶i̶m̶a̶t̶e̶ ̶C̶o̶l̶l̶e̶c̶t̶o̶r̶">T̶h̶e̶ ̶U̶l̶t̶i̶m̶a̶t̶e̶ ̶C̶o̶l̶l̶e̶c̶t̶o̶r̶<br>(not obtainable)</div>
+                    </div>
+                </section>
+
+                <section class="achievements-section">
+                    <h4 class="achievements-section__title">Event Exclusives</h4>
+                    <div class="achievements-subsection">
+                        <h5 class="achievements-section__subtitle">Spring &amp; Easter</h5>
+                        <div class="achievement-grid">
+                            <div class="achievement-itemE" data-time="the Easter Event" data-name="Happy Easter!">Happy Easter!</div>
+                        </div>
+                    </div>
+                    <div class="achievements-subsection">
+                        <h5 class="achievements-section__subtitle">Summer</h5>
+                        <div class="achievement-grid">
+                            <div class="achievement-itemSum" data-time="the Summer Event" data-name="Happy Summer!">Happy Summer!</div>
+                        </div>
+                    </div>
+                </section>
             </div>
         </div>
-
-        <button id="closeAchievements" class="achievementsBtns">Close</button>
     </div>
 
     <button id="toggleUiBtn">Hide UI</button>


### PR DESCRIPTION
## Summary
- Rebuild the achievements overlay with a draggable header, sectioned content, and updated markup to match the recent settings and inventory panels.
- Refresh the achievements styling with the new glass panel theme, responsive grids, and refined tooltips for each category.
- Extend the menu script so the achievements dialog can be dragged like other panels and reset its scroll position whenever it opens.

## Testing
- Not run (project has no automated tests).


------
https://chatgpt.com/codex/tasks/task_e_68d5232919908321b18ac6a606c6a040