### PR TITLE
Add cutscene failsafe to restore roll display

### DIFF
--- a/files/script.js
+++ b/files/script.js
@@ -38,6 +38,10 @@ let skipCutscene10K = true;
 let skipCutscene100K = true;
 let skipCutscene1M = true;
 let cooldownBuffActive = cooldownTime < BASE_COOLDOWN_TIME;
+let rollDisplayHiddenByUser = false;
+let cutsceneHidRollDisplay = false;
+let cutsceneActive = false;
+let cutsceneFailsafeTimeout = null;
 
 const STOPPABLE_AUDIO_IDS = [
   "suspenseAudio",
@@ -145,6 +149,70 @@ const STOPPABLE_AUDIO_IDS = [
   "esteggAudio",
   "isekailofiAudio"
 ];
+
+function setRollButtonEnabled(enabled) {
+  const button = document.getElementById("rollButton");
+  if (button) {
+    button.disabled = !enabled;
+  }
+}
+
+function restoreRollDisplayAfterCutscene() {
+  if (!cutsceneHidRollDisplay) {
+    return;
+  }
+
+  const rollDisplay = document.querySelector(".container");
+  if (!rollDisplay || rollDisplayHiddenByUser) {
+    cutsceneHidRollDisplay = false;
+    return;
+  }
+
+  rollDisplay.style.visibility = "visible";
+
+  const toggleBtn = document.getElementById("toggleRollDisplayBtn");
+  if (toggleBtn) {
+    toggleBtn.textContent = "Hide Roll & Display";
+  }
+
+  cutsceneHidRollDisplay = false;
+}
+
+function scheduleCutsceneFailsafe() {
+  clearTimeout(cutsceneFailsafeTimeout);
+  cutsceneFailsafeTimeout = setTimeout(() => {
+    if (!cutsceneActive) {
+      return;
+    }
+
+    console.warn("Cutscene safeguard triggered after timeout; restoring roll display state.");
+    isChangeEnabled = true;
+    finalizeCutsceneState();
+    setRollButtonEnabled(true);
+  }, 15000);
+}
+
+function finalizeCutsceneState() {
+  clearTimeout(cutsceneFailsafeTimeout);
+  cutsceneFailsafeTimeout = null;
+  cutsceneActive = false;
+  ensureBgStack();
+  if (__bgStack) {
+    __bgStack.classList.remove("is-hidden");
+  }
+  restoreRollDisplayAfterCutscene();
+}
+
+function hideRollDisplayForCutscene(container) {
+  if (!container) {
+    return;
+  }
+
+  const wasVisible = container.style.visibility !== "hidden";
+  cutsceneHidRollDisplay = !rollDisplayHiddenByUser && wasVisible;
+
+  container.style.visibility = "hidden";
+}
 
 const rarityCategories = {
   under100: [
@@ -774,6 +842,16 @@ document.getElementById("rollButton").addEventListener("click", function () {
     return;
   }
 
+  const rollDisplay = document.querySelector(".container");
+  if (rollDisplay && !rollDisplayHiddenByUser && rollDisplay.style.visibility === "hidden") {
+    rollDisplay.style.visibility = "visible";
+    cutsceneHidRollDisplay = false;
+    const toggleBtn = document.getElementById("toggleRollDisplayBtn");
+    if (toggleBtn) {
+      toggleBtn.textContent = "Hide Roll & Display";
+    }
+  }
+
   mainAudio.pause();
 
   checkAchievements();
@@ -897,7 +975,7 @@ document.getElementById("rollButton").addEventListener("click", function () {
     if (!titleCont) {
       return;
     }
-    titleCont.style.visibility = "hidden";
+    hideRollDisplayForCutscene(titleCont);
 
     if (rarity.type === "Fright [1 in 1,075]") {
       frightAudio.play();
@@ -9751,12 +9829,15 @@ document
 
     if (isVisible) {
       inventorySection.style.visibility = "hidden";
+      rollDisplayHiddenByUser = true;
       this.textContent = "Show Roll & Display";
     } else {
       inventorySection.style.visibility = "visible";
+      rollDisplayHiddenByUser = false;
+      cutsceneHidRollDisplay = false;
       this.textContent = "Hide Roll & Display";
     }
-});
+  });
 
 window.addEventListener("resize", function () {
   const container = document.querySelector(".container1");
@@ -10014,12 +10095,13 @@ function triggerScreenShakeByBucket(bucket) {
 
 function enableChange() {
   isChangeEnabled = true;
-  ensureBgStack();
-  __bgStack.classList.remove("is-hidden");
+  finalizeCutsceneState();
 }
 
 function disableChange() {
   isChangeEnabled = false;
+  cutsceneActive = true;
+  scheduleCutsceneFailsafe();
   // Hide stack during cutscenes (body backgrounds/gifs will show)
   if (__bgStack) __bgStack.classList.add("is-hidden");
 }
@@ -10988,6 +11070,27 @@ document.addEventListener("DOMContentLoaded", () => {
       isDraggingStats = false;
       headerStats.style.cursor = "grab";
     }
+  });
+});
+
+document.addEventListener("DOMContentLoaded", () => {
+  document.querySelectorAll(".inventory-delete-btn").forEach((button) => {
+    if (button.childElementCount > 0) {
+      return;
+    }
+
+    const label = button.textContent.replace(/\s+/g, " ").trim();
+    if (!label) {
+      return;
+    }
+
+    const labelSpan = document.createElement("span");
+    labelSpan.className = "inventory-delete-btn__label";
+    labelSpan.textContent = label;
+
+    button.textContent = "";
+    button.appendChild(labelSpan);
+    button.classList.add("inventory-delete-btn--overlay");
   });
 });
 

--- a/files/style.css
+++ b/files/style.css
@@ -1076,11 +1076,9 @@ body {
     flex: 1;
     overflow-y: auto;
     padding: 20px 24px 28px 24px;
-    display: grid;
+    display: flex;
+    flex-direction: column;
     gap: 18px;
-    grid-template-columns: minmax(0, 1fr);
-    grid-auto-flow: row dense;
-    align-content: start;
     min-height: 0;
     scrollbar-gutter: stable both-edges;
     scrollbar-width: thin;
@@ -1088,6 +1086,13 @@ body {
     overscroll-behavior: contain;
     touch-action: pan-y;
     -webkit-overflow-scrolling: touch;
+}
+
+.settings-layout {
+    display: grid;
+    gap: 18px;
+    grid-template-columns: repeat(auto-fit, minmax(260px, 1fr));
+    align-content: start;
 }
 
 .settings-body::-webkit-scrollbar {
@@ -1121,7 +1126,7 @@ body {
 }
 
 .settings-section--full {
-    grid-column: 1 / -1;
+    width: 100%;
 }
 
 .settings-section__title {
@@ -1139,7 +1144,7 @@ body {
 }
 
 @media (min-width: 720px) {
-    .settings-body {
+    .settings-layout {
         grid-template-columns: repeat(2, minmax(0, 1fr));
     }
 }
@@ -3015,6 +3020,64 @@ body.griCutsceneBgImg {
   border-color: rgba(176, 210, 255, 0.45);
 }
 
+.inventory-delete-btn--overlay {
+  position: relative;
+  color: var(--inventory-text-fallback, #f2f5ff);
+}
+
+.inventory-delete-btn__label {
+  display: block;
+  width: 100%;
+  text-align: center;
+  white-space: normal;
+  word-break: keep-all;
+  color: var(--inventory-text-fallback, #f2f5ff);
+  -webkit-text-fill-color: var(--inventory-text-fallback, #f2f5ff);
+  background-size: var(--inventory-text-gradient-size, 100% 100%);
+  background-position: var(--inventory-text-gradient-position, 50% 50%);
+  background-repeat: no-repeat;
+  transition: background-size 0.35s ease, background-position 0.35s ease, color 0.35s ease;
+}
+
+.inventory-delete-btn--overlay:hover .inventory-delete-btn__label {
+  color: var(--inventory-text-fallback, #f2f5ff);
+  -webkit-text-fill-color: var(--inventory-text-fallback, #f2f5ff);
+  background-size: var(--inventory-text-gradient-size, 100% 100%);
+  background-position: var(--inventory-text-gradient-position, 50% 50%);
+}
+
+@supports ((-webkit-background-clip: text) or (background-clip: text)) {
+  .inventory-delete-btn__label {
+    background-image: var(--inventory-text-gradient, linear-gradient(120deg, #e4ecff, #f9fbff));
+    -webkit-background-clip: text;
+    background-clip: text;
+    -webkit-text-fill-color: transparent;
+    color: transparent;
+    transition: background-image 0.35s ease, background-size 0.35s ease, background-position 0.35s ease;
+    animation: var(--inventory-text-gradient-animation, none);
+  }
+
+  .inventory-delete-btn--overlay:hover .inventory-delete-btn__label {
+    background-image: var(--inventory-text-gradient-hover, var(--inventory-text-gradient, linear-gradient(120deg, #f1f5ff, #ffffff)));
+    -webkit-background-clip: text;
+    background-clip: text;
+    -webkit-text-fill-color: transparent;
+    color: transparent;
+  }
+}
+
+@keyframes inventory-text-pan {
+  0% {
+    background-position: 0% 50%;
+  }
+  50% {
+    background-position: 100% 50%;
+  }
+  100% {
+    background-position: 0% 50%;
+  }
+}
+
 .inventory-group--basic {
   --group-bg-a: rgba(24, 46, 96, 0.72);
   --group-bg-b: rgba(12, 24, 48, 0.92);
@@ -3023,6 +3086,11 @@ body.griCutsceneBgImg {
 
 .inventory-group--basic .inventory-delete-btn {
   background: rgba(36, 58, 108, 0.78);
+}
+
+.inventory-group--basic .inventory-delete-btn--overlay {
+  --inventory-text-gradient: linear-gradient(130deg, #b7cbff, #f5f8ff);
+  --inventory-text-gradient-hover: linear-gradient(130deg, #d7e3ff, #ffffff);
 }
 
 .inventory-group--decent {
@@ -3035,10 +3103,20 @@ body.griCutsceneBgImg {
   background: rgba(24, 66, 66, 0.76);
 }
 
+.inventory-group--decent .inventory-delete-btn--overlay {
+  --inventory-text-gradient: linear-gradient(135deg, #54f7e2, #9df6ff);
+  --inventory-text-gradient-hover: linear-gradient(135deg, #7fffee, #d4fbff);
+}
+
 .inventory-group--grand {
   --group-bg-a: rgba(34, 68, 38, 0.72);
   --group-bg-b: rgba(16, 28, 24, 0.92);
   --group-border: rgba(138, 236, 160, 0.28);
+}
+
+.inventory-group--grand .inventory-delete-btn--overlay {
+  --inventory-text-gradient: linear-gradient(140deg, #9dffb5, #4be690, #e2ffe8);
+  --inventory-text-gradient-hover: linear-gradient(140deg, #c1ffd0, #6dffad, #ffffff);
 }
 
 .inventory-group--events {
@@ -3059,10 +3137,30 @@ body.griCutsceneBgImg {
   --group-border: rgba(255, 172, 140, 0.3);
 }
 
+.inventory-group--mastery .inventory-delete-btn--overlay {
+  --inventory-text-gradient: radial-gradient(circle at 20% 20%, #ffdfd3, #ff7ab8 45%, #ffc764 85%);
+  --inventory-text-gradient-hover: radial-gradient(circle at 20% 20%, #ffe8e0, #ff8ec6 45%, #ffd27d 85%);
+  --inventory-text-gradient-size: 220% 220%;
+  --inventory-text-gradient-animation: inventory-text-pan 7s ease-in-out infinite;
+}
+
 .inventory-group--supreme {
   --group-bg-a: rgba(68, 28, 74, 0.72);
   --group-bg-b: rgba(28, 12, 36, 0.92);
   --group-border: rgba(224, 156, 255, 0.32);
+}
+
+.inventory-group--supreme .inventory-delete-btn--overlay {
+  --inventory-text-gradient: radial-gradient(circle at 30% 20%, #bbf7ff, #8c5bff 45%, #ffd67a 80%);
+  --inventory-text-gradient-hover: radial-gradient(circle at 30% 20%, #d6fbff, #a57cff 45%, #ffe49c 80%);
+  --inventory-text-gradient-size: 250% 250%;
+  --inventory-text-gradient-animation: inventory-text-pan 6s ease-in-out infinite;
+}
+
+#deleteAllPumpkinButton.inventory-delete-btn--overlay {
+  --inventory-text-gradient: linear-gradient(135deg, #ff9c3b, #ffd9a3, #8f8f93);
+  --inventory-text-gradient-hover: linear-gradient(135deg, #ffb76a, #ffe6c4, #b7b7bb);
+  --inventory-text-fallback: #ffd9a8;
 }
 
 #toggleInventoryBtn {

--- a/index.html
+++ b/index.html
@@ -40,47 +40,49 @@
                 <button id="closeSettings" class="settings-close-btn" type="button">Close</button>
             </div>
             <div class="settings-body">
-                <section class="settings-section">
-                    <h4 class="settings-section__title">Audio</h4>
-                    <div class="settings-audio">
-                        <label class="settings-audio__label" for="audioSlider">Master Volume</label>
-                        <div class="settings-audio__controls">
-                            <div class="settings-audio__slider">
-                                <input type="range" id="audioSlider" min="0" max="1" step="0.01" value="1">
-                                <span id="audioSliderValue" class="settings-audio__value">100%</span>
+                <div class="settings-layout">
+                    <section class="settings-section">
+                        <h4 class="settings-section__title">Audio</h4>
+                        <div class="settings-audio">
+                            <label class="settings-audio__label" for="audioSlider">Master Volume</label>
+                            <div class="settings-audio__controls">
+                                <div class="settings-audio__slider">
+                                    <input type="range" id="audioSlider" min="0" max="1" step="0.01" value="1">
+                                    <span id="audioSliderValue" class="settings-audio__value">100%</span>
+                                </div>
+                                <button id="muteButton" class="settings-btn settings-btn--ghost" type="button">Mute</button>
                             </div>
-                            <button id="muteButton" class="settings-btn settings-btn--ghost" type="button">Mute</button>
                         </div>
-                    </div>
-                </section>
+                    </section>
 
-                <section class="settings-section">
-                    <h4 class="settings-section__title">Data Management</h4>
-                    <div class="settings-grid">
-                        <button id="saveButton" class="settings-btn" type="button">Save Data</button>
-                        <button id="importButton" class="settings-btn" type="button">Import Data</button>
-                        <button id="resetDataButton" class="settings-btn settings-btn--danger" type="button">Reset Data</button>
-                    </div>
-                    <p id="status" class="statusImport"></p>
-                </section>
+                    <section class="settings-section">
+                        <h4 class="settings-section__title">Data Management</h4>
+                        <div class="settings-grid">
+                            <button id="saveButton" class="settings-btn" type="button">Save Data</button>
+                            <button id="importButton" class="settings-btn" type="button">Import Data</button>
+                            <button id="resetDataButton" class="settings-btn settings-btn--danger" type="button">Reset Data</button>
+                        </div>
+                        <p id="status" class="statusImport"></p>
+                    </section>
 
-                <section class="settings-section">
-                    <h4 class="settings-section__title">Interface</h4>
-                    <div class="settings-grid">
-                        <button id="toggleRollDisplayBtn" class="settings-btn settings-btn--ghost" type="button">Hide Roll &amp; Display</button>
-                        <button id="toggleRollHistoryBtn" class="settings-btn settings-btn--ghost" type="button">Hide Roll History</button>
-                    </div>
-                </section>
+                    <section class="settings-section">
+                        <h4 class="settings-section__title">Interface</h4>
+                        <div class="settings-grid">
+                            <button id="toggleRollDisplayBtn" class="settings-btn settings-btn--ghost" type="button">Hide Roll &amp; Display</button>
+                            <button id="toggleRollHistoryBtn" class="settings-btn settings-btn--ghost" type="button">Hide Roll History</button>
+                        </div>
+                    </section>
 
-                <section class="settings-section">
-                    <h4 class="settings-section__title">Cutscene Skip</h4>
-                    <div id="rarityChecklistC" class="settings-chip-group">
-                        <button id="toggleCutscene1K" class="cutsceneSkipBtb" type="button"><span id="1KTxt" class="under1kT">Skip Decent Cutscenes</span></button>
-                        <button id="toggleCutscene10K" class="cutsceneSkipBtb" type="button"><span id="10KTxt" class="under10kT">Skip Grand Cutscenes</span></button>
-                        <button id="toggleCutscene100K" class="cutsceneSkipBtb" type="button"><span id="100KTxt" class="under100k">Skip Mastery Cutscenes</span></button>
-                        <button id="toggleCutscene1M" class="cutsceneSkipBtb" type="button"><span id="1MTxt" class="under1mBtn">Skip Supreme Cutscenes</span></button>
-                    </div>
-                </section>
+                    <section class="settings-section">
+                        <h4 class="settings-section__title">Cutscene Skip</h4>
+                        <div id="rarityChecklistC" class="settings-chip-group">
+                            <button id="toggleCutscene1K" class="cutsceneSkipBtb" type="button"><span id="1KTxt" class="under1kT">Skip Decent Cutscenes</span></button>
+                            <button id="toggleCutscene10K" class="cutsceneSkipBtb" type="button"><span id="10KTxt" class="under10kT">Skip Grand Cutscenes</span></button>
+                            <button id="toggleCutscene100K" class="cutsceneSkipBtb" type="button"><span id="100KTxt" class="under100k">Skip Mastery Cutscenes</span></button>
+                            <button id="toggleCutscene1M" class="cutsceneSkipBtb" type="button"><span id="1MTxt" class="under1mBtn">Skip Supreme Cutscenes</span></button>
+                        </div>
+                    </section>
+                </div>
 
                 <section class="settings-section settings-section--full">
                     <h4 class="settings-section__title">Auto Delete Rarity</h4>


### PR DESCRIPTION
## Summary
- add guard logic that tracks when the roll display is hidden by cutscenes and restores it if the sequence stalls
- hook the new failsafe into cutscene start/finish flows and roll-button clicks so the UI and background stack recover automatically

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68d5197d7bd08321a70e43244cf75d50