### PR TITLE
Rework statistics menu with card-based layout

### DIFF
--- a/files/script.js
+++ b/files/script.js
@@ -38,6 +38,10 @@ let skipCutscene10K = true;
 let skipCutscene100K = true;
 let skipCutscene1M = true;
 let cooldownBuffActive = cooldownTime < BASE_COOLDOWN_TIME;
+let rollDisplayHiddenByUser = false;
+let cutsceneHidRollDisplay = false;
+let cutsceneActive = false;
+let cutsceneFailsafeTimeout = null;
 
 const STOPPABLE_AUDIO_IDS = [
   "suspenseAudio",
@@ -145,6 +149,70 @@ const STOPPABLE_AUDIO_IDS = [
   "esteggAudio",
   "isekailofiAudio"
 ];
+
+function setRollButtonEnabled(enabled) {
+  const button = document.getElementById("rollButton");
+  if (button) {
+    button.disabled = !enabled;
+  }
+}
+
+function restoreRollDisplayAfterCutscene() {
+  if (!cutsceneHidRollDisplay) {
+    return;
+  }
+
+  const rollDisplay = document.querySelector(".container");
+  if (!rollDisplay || rollDisplayHiddenByUser) {
+    cutsceneHidRollDisplay = false;
+    return;
+  }
+
+  rollDisplay.style.visibility = "visible";
+
+  const toggleBtn = document.getElementById("toggleRollDisplayBtn");
+  if (toggleBtn) {
+    toggleBtn.textContent = "Hide Roll & Display";
+  }
+
+  cutsceneHidRollDisplay = false;
+}
+
+function scheduleCutsceneFailsafe() {
+  clearTimeout(cutsceneFailsafeTimeout);
+  cutsceneFailsafeTimeout = setTimeout(() => {
+    if (!cutsceneActive) {
+      return;
+    }
+
+    console.warn("Cutscene safeguard triggered after timeout; restoring roll display state.");
+    isChangeEnabled = true;
+    finalizeCutsceneState();
+    setRollButtonEnabled(true);
+  }, 15000);
+}
+
+function finalizeCutsceneState() {
+  clearTimeout(cutsceneFailsafeTimeout);
+  cutsceneFailsafeTimeout = null;
+  cutsceneActive = false;
+  ensureBgStack();
+  if (__bgStack) {
+    __bgStack.classList.remove("is-hidden");
+  }
+  restoreRollDisplayAfterCutscene();
+}
+
+function hideRollDisplayForCutscene(container) {
+  if (!container) {
+    return;
+  }
+
+  const wasVisible = container.style.visibility !== "hidden";
+  cutsceneHidRollDisplay = !rollDisplayHiddenByUser && wasVisible;
+
+  container.style.visibility = "hidden";
+}
 
 const rarityCategories = {
   under100: [
@@ -774,6 +842,16 @@ document.getElementById("rollButton").addEventListener("click", function () {
     return;
   }
 
+  const rollDisplay = document.querySelector(".container");
+  if (rollDisplay && !rollDisplayHiddenByUser && rollDisplay.style.visibility === "hidden") {
+    rollDisplay.style.visibility = "visible";
+    cutsceneHidRollDisplay = false;
+    const toggleBtn = document.getElementById("toggleRollDisplayBtn");
+    if (toggleBtn) {
+      toggleBtn.textContent = "Hide Roll & Display";
+    }
+  }
+
   mainAudio.pause();
 
   checkAchievements();
@@ -897,7 +975,7 @@ document.getElementById("rollButton").addEventListener("click", function () {
     if (!titleCont) {
       return;
     }
-    titleCont.style.visibility = "hidden";
+    hideRollDisplayForCutscene(titleCont);
 
     if (rarity.type === "Fright [1 in 1,075]") {
       frightAudio.play();
@@ -9751,12 +9829,15 @@ document
 
     if (isVisible) {
       inventorySection.style.visibility = "hidden";
+      rollDisplayHiddenByUser = true;
       this.textContent = "Show Roll & Display";
     } else {
       inventorySection.style.visibility = "visible";
+      rollDisplayHiddenByUser = false;
+      cutsceneHidRollDisplay = false;
       this.textContent = "Hide Roll & Display";
     }
-});
+  });
 
 window.addEventListener("resize", function () {
   const container = document.querySelector(".container1");
@@ -10014,12 +10095,13 @@ function triggerScreenShakeByBucket(bucket) {
 
 function enableChange() {
   isChangeEnabled = true;
-  ensureBgStack();
-  __bgStack.classList.remove("is-hidden");
+  finalizeCutsceneState();
 }
 
 function disableChange() {
   isChangeEnabled = false;
+  cutsceneActive = true;
+  scheduleCutsceneFailsafe();
   // Hide stack during cutscenes (body backgrounds/gifs will show)
   if (__bgStack) __bgStack.classList.add("is-hidden");
 }
@@ -10915,7 +10997,7 @@ document.addEventListener("DOMContentLoaded", () => {
   const settingsMenu = document.getElementById("settingsMenu");
   const settingsHeader = settingsMenu?.querySelector(".settings-header");
   const settingsBody = settingsMenu?.querySelector(".settings-body");
-  const headerStats = statsMenu.querySelector("h3");
+  const statsDragHandle = statsMenu?.querySelector(".stats-menu__drag-handle");
   let isDraggingSettings = false;
   let isDraggingStats = false;
   let offsetX = 0;
@@ -10942,12 +11024,22 @@ document.addEventListener("DOMContentLoaded", () => {
     });
   }
 
-  if (headerStats) {
-    headerStats.addEventListener("mousedown", (event) => {
+  if (statsMenu && statsDragHandle) {
+    statsDragHandle.addEventListener("mousedown", (event) => {
+      if (event.button !== 0) {
+        return;
+      }
+
+      const rect = statsMenu.getBoundingClientRect();
+      statsMenu.style.left = `${rect.left}px`;
+      statsMenu.style.top = `${rect.top}px`;
+      statsMenu.style.transform = "none";
+
+      offsetXStyle = event.clientX - rect.left;
+      offsetYStyle = event.clientY - rect.top;
       isDraggingStats = true;
-      offsetXStyle = event.clientX - statsMenu.offsetLeft;
-      offsetYStyle = event.clientY - statsMenu.offsetTop;
-      headerStats.style.cursor = "grabbing";
+      statsDragHandle.classList.add("is-dragging");
+      event.preventDefault();
     });
   }
 
@@ -10986,8 +11078,29 @@ document.addEventListener("DOMContentLoaded", () => {
 
     if (isDraggingStats) {
       isDraggingStats = false;
-      headerStats.style.cursor = "grab";
+      statsDragHandle?.classList.remove("is-dragging");
     }
+  });
+});
+
+document.addEventListener("DOMContentLoaded", () => {
+  document.querySelectorAll(".inventory-delete-btn").forEach((button) => {
+    if (button.childElementCount > 0) {
+      return;
+    }
+
+    const label = button.textContent.replace(/\s+/g, " ").trim();
+    if (!label) {
+      return;
+    }
+
+    const labelSpan = document.createElement("span");
+    labelSpan.className = "inventory-delete-btn__label";
+    labelSpan.textContent = label;
+
+    button.textContent = "";
+    button.appendChild(labelSpan);
+    button.classList.add("inventory-delete-btn--overlay");
   });
 });
 

--- a/files/style.css
+++ b/files/style.css
@@ -1002,9 +1002,14 @@ body {
 }
 
 .dragTxt {
-    opacity: 0.5;
-    padding: 3px;
-    cursor: grab;
+    opacity: 0.75;
+    padding: 0;
+    cursor: inherit;
+    text-transform: uppercase;
+    letter-spacing: 0.14em;
+    font-size: 0.78rem;
+    font-weight: 600;
+    user-select: none;
 }
 
 #settingsMenu {
@@ -1076,11 +1081,9 @@ body {
     flex: 1;
     overflow-y: auto;
     padding: 20px 24px 28px 24px;
-    display: grid;
+    display: flex;
+    flex-direction: column;
     gap: 18px;
-    grid-template-columns: minmax(0, 1fr);
-    grid-auto-flow: row dense;
-    align-content: start;
     min-height: 0;
     scrollbar-gutter: stable both-edges;
     scrollbar-width: thin;
@@ -1088,6 +1091,13 @@ body {
     overscroll-behavior: contain;
     touch-action: pan-y;
     -webkit-overflow-scrolling: touch;
+}
+
+.settings-layout {
+    display: grid;
+    gap: 18px;
+    grid-template-columns: repeat(auto-fit, minmax(260px, 1fr));
+    align-content: start;
 }
 
 .settings-body::-webkit-scrollbar {
@@ -1121,7 +1131,7 @@ body {
 }
 
 .settings-section--full {
-    grid-column: 1 / -1;
+    width: 100%;
 }
 
 .settings-section__title {
@@ -1139,7 +1149,7 @@ body {
 }
 
 @media (min-width: 720px) {
-    .settings-body {
+    .settings-layout {
         grid-template-columns: repeat(2, minmax(0, 1fr));
     }
 }
@@ -1323,15 +1333,33 @@ body {
 }
 
 .statsBtns {
-    display: inline-block;
-    padding: 10px 15px;
-    margin: 10px 0;
+    width: 100%;
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    gap: 8px;
+    padding: 12px 18px;
     font-size: 1rem;
-    font-weight: bold;
+    font-weight: 700;
+    letter-spacing: 0.04em;
     border: none;
-    border-radius: 5px;
+    border-radius: 12px;
     cursor: pointer;
-    transition: all 0.3s ease-in-out;
+    color: #0b0d22;
+    background:
+        linear-gradient(135deg, rgba(150, 230, 255, 0.95) 0%, rgba(127, 176, 255, 0.98) 48%, rgba(198, 146, 255, 0.98) 100%);
+    box-shadow: 0 16px 32px rgba(77, 118, 255, 0.35);
+    transition: transform 0.22s ease, box-shadow 0.22s ease;
+}
+
+.statsBtns:hover {
+    transform: translateY(-2px) scale(1.01);
+    box-shadow: 0 22px 36px rgba(91, 129, 255, 0.45);
+}
+
+.statsBtns:active {
+    transform: translateY(0);
+    box-shadow: 0 12px 24px rgba(91, 129, 255, 0.32);
 }
 
 .aSlid {
@@ -3015,6 +3043,64 @@ body.griCutsceneBgImg {
   border-color: rgba(176, 210, 255, 0.45);
 }
 
+.inventory-delete-btn--overlay {
+  position: relative;
+  color: var(--inventory-text-fallback, #f2f5ff);
+}
+
+.inventory-delete-btn__label {
+  display: block;
+  width: 100%;
+  text-align: center;
+  white-space: normal;
+  word-break: keep-all;
+  color: var(--inventory-text-fallback, #f2f5ff);
+  -webkit-text-fill-color: var(--inventory-text-fallback, #f2f5ff);
+  background-size: var(--inventory-text-gradient-size, 100% 100%);
+  background-position: var(--inventory-text-gradient-position, 50% 50%);
+  background-repeat: no-repeat;
+  transition: background-size 0.35s ease, background-position 0.35s ease, color 0.35s ease;
+}
+
+.inventory-delete-btn--overlay:hover .inventory-delete-btn__label {
+  color: var(--inventory-text-fallback, #f2f5ff);
+  -webkit-text-fill-color: var(--inventory-text-fallback, #f2f5ff);
+  background-size: var(--inventory-text-gradient-size, 100% 100%);
+  background-position: var(--inventory-text-gradient-position, 50% 50%);
+}
+
+@supports ((-webkit-background-clip: text) or (background-clip: text)) {
+  .inventory-delete-btn__label {
+    background-image: var(--inventory-text-gradient, linear-gradient(120deg, #e4ecff, #f9fbff));
+    -webkit-background-clip: text;
+    background-clip: text;
+    -webkit-text-fill-color: transparent;
+    color: transparent;
+    transition: background-image 0.35s ease, background-size 0.35s ease, background-position 0.35s ease;
+    animation: var(--inventory-text-gradient-animation, none);
+  }
+
+  .inventory-delete-btn--overlay:hover .inventory-delete-btn__label {
+    background-image: var(--inventory-text-gradient-hover, var(--inventory-text-gradient, linear-gradient(120deg, #f1f5ff, #ffffff)));
+    -webkit-background-clip: text;
+    background-clip: text;
+    -webkit-text-fill-color: transparent;
+    color: transparent;
+  }
+}
+
+@keyframes inventory-text-pan {
+  0% {
+    background-position: 0% 50%;
+  }
+  50% {
+    background-position: 100% 50%;
+  }
+  100% {
+    background-position: 0% 50%;
+  }
+}
+
 .inventory-group--basic {
   --group-bg-a: rgba(24, 46, 96, 0.72);
   --group-bg-b: rgba(12, 24, 48, 0.92);
@@ -3023,6 +3109,11 @@ body.griCutsceneBgImg {
 
 .inventory-group--basic .inventory-delete-btn {
   background: rgba(36, 58, 108, 0.78);
+}
+
+.inventory-group--basic .inventory-delete-btn--overlay {
+  --inventory-text-gradient: linear-gradient(130deg, #b7cbff, #f5f8ff);
+  --inventory-text-gradient-hover: linear-gradient(130deg, #d7e3ff, #ffffff);
 }
 
 .inventory-group--decent {
@@ -3035,10 +3126,20 @@ body.griCutsceneBgImg {
   background: rgba(24, 66, 66, 0.76);
 }
 
+.inventory-group--decent .inventory-delete-btn--overlay {
+  --inventory-text-gradient: linear-gradient(135deg, #54f7e2, #9df6ff);
+  --inventory-text-gradient-hover: linear-gradient(135deg, #7fffee, #d4fbff);
+}
+
 .inventory-group--grand {
   --group-bg-a: rgba(34, 68, 38, 0.72);
   --group-bg-b: rgba(16, 28, 24, 0.92);
   --group-border: rgba(138, 236, 160, 0.28);
+}
+
+.inventory-group--grand .inventory-delete-btn--overlay {
+  --inventory-text-gradient: linear-gradient(140deg, #9dffb5, #4be690, #e2ffe8);
+  --inventory-text-gradient-hover: linear-gradient(140deg, #c1ffd0, #6dffad, #ffffff);
 }
 
 .inventory-group--events {
@@ -3059,10 +3160,30 @@ body.griCutsceneBgImg {
   --group-border: rgba(255, 172, 140, 0.3);
 }
 
+.inventory-group--mastery .inventory-delete-btn--overlay {
+  --inventory-text-gradient: radial-gradient(circle at 20% 20%, #ffdfd3, #ff7ab8 45%, #ffc764 85%);
+  --inventory-text-gradient-hover: radial-gradient(circle at 20% 20%, #ffe8e0, #ff8ec6 45%, #ffd27d 85%);
+  --inventory-text-gradient-size: 220% 220%;
+  --inventory-text-gradient-animation: inventory-text-pan 7s ease-in-out infinite;
+}
+
 .inventory-group--supreme {
   --group-bg-a: rgba(68, 28, 74, 0.72);
   --group-bg-b: rgba(28, 12, 36, 0.92);
   --group-border: rgba(224, 156, 255, 0.32);
+}
+
+.inventory-group--supreme .inventory-delete-btn--overlay {
+  --inventory-text-gradient: radial-gradient(circle at 30% 20%, #bbf7ff, #8c5bff 45%, #ffd67a 80%);
+  --inventory-text-gradient-hover: radial-gradient(circle at 30% 20%, #d6fbff, #a57cff 45%, #ffe49c 80%);
+  --inventory-text-gradient-size: 250% 250%;
+  --inventory-text-gradient-animation: inventory-text-pan 6s ease-in-out infinite;
+}
+
+#deleteAllPumpkinButton.inventory-delete-btn--overlay {
+  --inventory-text-gradient: linear-gradient(135deg, #ff9c3b, #ffd9a3, #8f8f93);
+  --inventory-text-gradient-hover: linear-gradient(135deg, #ffb76a, #ffe6c4, #b7b7bb);
+  --inventory-text-fallback: #ffd9a8;
 }
 
 #toggleInventoryBtn {
@@ -3116,40 +3237,6 @@ body.griCutsceneBgImg {
     border-radius: 15px;
     padding: 10px 6px;
     z-index: 9999999;
-}
-
-.statistics {
-    color: #fff;
-    margin-bottom: 40px;
-}
-
-.rollsCount1 {
-    position: relative;
-    background: #ffffff05;
-    backdrop-filter: blur(5px);
-    color: #fff;
-    margin-bottom: 20px;
-    border-radius: 15px;
-    padding: 10px 6px;
-    z-index: 9999999;
-}
-
-.rollsCount2 {
-    background: #ffffff21;
-    color: #fff;
-    margin-bottom: 20px;
-    border-radius: 15px;
-    padding: 10px 6px;
-    z-index: 9999999;
-}
-
-.timerTotal {
-    margin-top: 20px;
-}
-
-.count1 {
-    top: 22px;
-    left: 30px;
 }
 
 .count {
@@ -4300,6 +4387,198 @@ body.griCutsceneBgImg {
     background: rgba(255, 0, 0, 1);
 }
 
+#statsMenu {
+    position: fixed;
+    top: 50%;
+    left: 50%;
+    transform: translate(-50%, -50%);
+    width: min(520px, calc(100vw - 32px));
+    max-height: min(82vh, 560px);
+    z-index: 90000000;
+    color: #f4f7ff;
+    font-family: 'Arial', sans-serif;
+}
+
+.stats-menu__panel {
+    position: relative;
+    display: flex;
+    flex-direction: column;
+    gap: 24px;
+    padding: 28px 28px 24px;
+    background:
+        linear-gradient(168deg, rgba(23, 26, 46, 0.92), rgba(8, 10, 26, 0.94)),
+        url(backgrounds/rng_master.png);
+    background-size: cover;
+    border-radius: 22px;
+    border: 1px solid rgba(122, 159, 255, 0.35);
+    box-shadow: 0 28px 68px rgba(4, 8, 30, 0.65);
+    overflow: hidden;
+    backdrop-filter: blur(10px);
+}
+
+.stats-menu__panel::before {
+    content: "";
+    position: absolute;
+    inset: 0;
+    background: radial-gradient(120% 120% at 0% 0%, rgba(121, 204, 255, 0.16) 0%, transparent 55%),
+                radial-gradient(100% 120% at 100% 0%, rgba(209, 132, 255, 0.2) 0%, transparent 55%),
+                linear-gradient(185deg, rgba(255, 255, 255, 0.05), transparent 48%, rgba(139, 202, 255, 0.08) 98%);
+    pointer-events: none;
+    mix-blend-mode: screen;
+}
+
+.stats-menu__drag-handle {
+    position: relative;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    gap: 8px;
+    padding: 10px 16px 14px;
+    border-radius: 14px;
+    border: 1px solid rgba(255, 255, 255, 0.08);
+    background: linear-gradient(120deg, rgba(255, 255, 255, 0.08), rgba(255, 255, 255, 0.02));
+    box-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.12);
+    cursor: grab;
+    text-transform: uppercase;
+    letter-spacing: 0.12em;
+    color: rgba(215, 226, 255, 0.8);
+    font-size: 0.75rem;
+    font-weight: 600;
+    user-select: none;
+}
+
+.stats-menu__drag-handle::before {
+    content: "";
+    width: 28px;
+    height: 3px;
+    border-radius: 999px;
+    background: linear-gradient(90deg, rgba(255, 255, 255, 0.55), rgba(255, 255, 255, 0.15));
+    box-shadow: 0 6px 12px rgba(13, 17, 38, 0.45);
+}
+
+.stats-menu__drag-handle.is-dragging,
+.stats-menu__drag-handle:active {
+    cursor: grabbing;
+}
+
+.stats-menu__header {
+    position: relative;
+    text-align: center;
+    display: flex;
+    flex-direction: column;
+    gap: 8px;
+    padding-bottom: 6px;
+}
+
+.stats-menu__title {
+    font-size: clamp(1.8rem, 1.4rem + 1vw, 2.4rem);
+    font-weight: 800;
+    letter-spacing: 0.04em;
+    text-transform: uppercase;
+    margin: 0;
+    color: #fdfdff;
+    text-shadow: 0 6px 24px rgba(47, 77, 180, 0.6);
+}
+
+.stats-menu__subtitle {
+    margin: 0;
+    color: rgba(226, 235, 255, 0.65);
+    font-size: 0.9rem;
+    letter-spacing: 0.02em;
+}
+
+.stats-menu__content {
+    display: grid;
+    gap: 18px;
+    grid-auto-rows: minmax(0, 1fr);
+}
+
+@media (min-width: 520px) {
+    .stats-menu__content {
+        grid-template-columns: repeat(2, minmax(0, 1fr));
+    }
+}
+
+.stat-card {
+    position: relative;
+    padding: 20px 22px 24px;
+    border-radius: 18px;
+    border: 1px solid rgba(255, 255, 255, 0.08);
+    background: linear-gradient(162deg, rgba(16, 21, 44, 0.82), rgba(17, 16, 40, 0.66));
+    box-shadow: 0 18px 36px rgba(8, 12, 36, 0.55);
+    overflow: hidden;
+    min-height: 160px;
+    display: flex;
+    flex-direction: column;
+    gap: 14px;
+}
+
+.stat-card::before {
+    content: "";
+    position: absolute;
+    inset: 0;
+    opacity: 0.9;
+    pointer-events: none;
+    transition: opacity 0.3s ease;
+}
+
+.stat-card--rolls::before {
+    background: linear-gradient(135deg, rgba(117, 79, 255, 0.16), rgba(89, 196, 255, 0.2));
+}
+
+.stat-card--playtime::before {
+    background: linear-gradient(135deg, rgba(255, 177, 109, 0.18), rgba(122, 255, 206, 0.18));
+}
+
+.stat-card:hover::before {
+    opacity: 1;
+}
+
+.stat-card__label {
+    position: relative;
+    font-size: 0.85rem;
+    font-weight: 700;
+    letter-spacing: 0.15em;
+    text-transform: uppercase;
+    color: rgba(221, 230, 255, 0.75);
+    margin: 0;
+}
+
+.stat-card__value {
+    position: relative;
+    font-size: clamp(2rem, 1.4rem + 1.2vw, 2.8rem);
+    font-weight: 800;
+    color: #fdfcff;
+    text-shadow: 0 12px 26px rgba(36, 62, 120, 0.65);
+    letter-spacing: 0.05em;
+    font-variant-numeric: tabular-nums;
+}
+
+.stat-card__hint {
+    position: relative;
+    margin: 0;
+    color: rgba(218, 228, 255, 0.55);
+    font-size: 0.78rem;
+    line-height: 1.4;
+}
+
+.stats-menu__footer {
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    margin-top: 8px;
+}
+
+@media (max-width: 520px) {
+    .stats-menu__panel {
+        padding: 24px 22px 20px;
+    }
+
+    .stat-card {
+        min-height: unset;
+    }
+}
+
 .AutoDeletionTxt {
     background: #222;
     padding: 10px;
@@ -4333,23 +4612,6 @@ body.griCutsceneBgImg {
   
 .cutsceneSkipBtb:hover {
     background: #555;
-}
-
-#statsMenu {
-    position: fixed;
-    top: 50%;
-    left: 50%;
-    transform: translate(-50%, -50%);
-    width: 20%;
-    padding: 20px;
-    background: url(backgrounds/rng_master.png);
-    border-radius: 10px;
-    border-style: groove;
-    box-shadow: 0 4px 10px rgba(0, 0, 0, 0.5);
-    z-index: 90000000;
-    color: white;
-    font-family: 'Arial', sans-serif;
-    text-align: center;
 }
 
 @keyframes rngShakeXS {

--- a/index.html
+++ b/index.html
@@ -40,47 +40,49 @@
                 <button id="closeSettings" class="settings-close-btn" type="button">Close</button>
             </div>
             <div class="settings-body">
-                <section class="settings-section">
-                    <h4 class="settings-section__title">Audio</h4>
-                    <div class="settings-audio">
-                        <label class="settings-audio__label" for="audioSlider">Master Volume</label>
-                        <div class="settings-audio__controls">
-                            <div class="settings-audio__slider">
-                                <input type="range" id="audioSlider" min="0" max="1" step="0.01" value="1">
-                                <span id="audioSliderValue" class="settings-audio__value">100%</span>
+                <div class="settings-layout">
+                    <section class="settings-section">
+                        <h4 class="settings-section__title">Audio</h4>
+                        <div class="settings-audio">
+                            <label class="settings-audio__label" for="audioSlider">Master Volume</label>
+                            <div class="settings-audio__controls">
+                                <div class="settings-audio__slider">
+                                    <input type="range" id="audioSlider" min="0" max="1" step="0.01" value="1">
+                                    <span id="audioSliderValue" class="settings-audio__value">100%</span>
+                                </div>
+                                <button id="muteButton" class="settings-btn settings-btn--ghost" type="button">Mute</button>
                             </div>
-                            <button id="muteButton" class="settings-btn settings-btn--ghost" type="button">Mute</button>
                         </div>
-                    </div>
-                </section>
+                    </section>
 
-                <section class="settings-section">
-                    <h4 class="settings-section__title">Data Management</h4>
-                    <div class="settings-grid">
-                        <button id="saveButton" class="settings-btn" type="button">Save Data</button>
-                        <button id="importButton" class="settings-btn" type="button">Import Data</button>
-                        <button id="resetDataButton" class="settings-btn settings-btn--danger" type="button">Reset Data</button>
-                    </div>
-                    <p id="status" class="statusImport"></p>
-                </section>
+                    <section class="settings-section">
+                        <h4 class="settings-section__title">Data Management</h4>
+                        <div class="settings-grid">
+                            <button id="saveButton" class="settings-btn" type="button">Save Data</button>
+                            <button id="importButton" class="settings-btn" type="button">Import Data</button>
+                            <button id="resetDataButton" class="settings-btn settings-btn--danger" type="button">Reset Data</button>
+                        </div>
+                        <p id="status" class="statusImport"></p>
+                    </section>
 
-                <section class="settings-section">
-                    <h4 class="settings-section__title">Interface</h4>
-                    <div class="settings-grid">
-                        <button id="toggleRollDisplayBtn" class="settings-btn settings-btn--ghost" type="button">Hide Roll &amp; Display</button>
-                        <button id="toggleRollHistoryBtn" class="settings-btn settings-btn--ghost" type="button">Hide Roll History</button>
-                    </div>
-                </section>
+                    <section class="settings-section">
+                        <h4 class="settings-section__title">Interface</h4>
+                        <div class="settings-grid">
+                            <button id="toggleRollDisplayBtn" class="settings-btn settings-btn--ghost" type="button">Hide Roll &amp; Display</button>
+                            <button id="toggleRollHistoryBtn" class="settings-btn settings-btn--ghost" type="button">Hide Roll History</button>
+                        </div>
+                    </section>
 
-                <section class="settings-section">
-                    <h4 class="settings-section__title">Cutscene Skip</h4>
-                    <div id="rarityChecklistC" class="settings-chip-group">
-                        <button id="toggleCutscene1K" class="cutsceneSkipBtb" type="button"><span id="1KTxt" class="under1kT">Skip Decent Cutscenes</span></button>
-                        <button id="toggleCutscene10K" class="cutsceneSkipBtb" type="button"><span id="10KTxt" class="under10kT">Skip Grand Cutscenes</span></button>
-                        <button id="toggleCutscene100K" class="cutsceneSkipBtb" type="button"><span id="100KTxt" class="under100k">Skip Mastery Cutscenes</span></button>
-                        <button id="toggleCutscene1M" class="cutsceneSkipBtb" type="button"><span id="1MTxt" class="under1mBtn">Skip Supreme Cutscenes</span></button>
-                    </div>
-                </section>
+                    <section class="settings-section">
+                        <h4 class="settings-section__title">Cutscene Skip</h4>
+                        <div id="rarityChecklistC" class="settings-chip-group">
+                            <button id="toggleCutscene1K" class="cutsceneSkipBtb" type="button"><span id="1KTxt" class="under1kT">Skip Decent Cutscenes</span></button>
+                            <button id="toggleCutscene10K" class="cutsceneSkipBtb" type="button"><span id="10KTxt" class="under10kT">Skip Grand Cutscenes</span></button>
+                            <button id="toggleCutscene100K" class="cutsceneSkipBtb" type="button"><span id="100KTxt" class="under100k">Skip Mastery Cutscenes</span></button>
+                            <button id="toggleCutscene1M" class="cutsceneSkipBtb" type="button"><span id="1MTxt" class="under1mBtn">Skip Supreme Cutscenes</span></button>
+                        </div>
+                    </section>
+                </div>
 
                 <section class="settings-section settings-section--full">
                     <h4 class="settings-section__title">Auto Delete Rarity</h4>
@@ -97,19 +99,31 @@
         </div>
     </div>
 
-    <div id="statsMenu" class="stats-menu" style="display: none;"> <h3 class="dragTxt">Hold me to drag</h3>
-            <div class="rollsCount1">
-                <h1 class="statistics">Statistics</h1>
-                <h3 class="count1">Total Rolls:</h3>
-                <a class="totalCount1" id="rollCountDisplay1">NaN</a>
-                <br>
-                <div class="timer-container">
-                    <h3 class="timerTotal">Playtime Timer:</h3>
-                    <div class="timer" id="timer">00:00:00</div>
-                </div>
+    <div id="statsMenu" class="stats-menu" style="display: none;">
+        <div class="stats-menu__panel">
+            <div class="stats-menu__drag-handle">
+                <span class="dragTxt">Hold me to drag</span>
             </div>
-
-        <button id="closeStats" class="statsBtns">Close</button>
+            <header class="stats-menu__header">
+                <h1 class="stats-menu__title">Statistics</h1>
+                <p class="stats-menu__subtitle">Track your progress at a glance.</p>
+            </header>
+            <div class="stats-menu__content">
+                <article class="stat-card stat-card--rolls">
+                    <h2 class="stat-card__label">Total Rolls</h2>
+                    <div class="stat-card__value" id="rollCountDisplay1">NaN</div>
+                    <p class="stat-card__hint">All-time rolls across every session.</p>
+                </article>
+                <article class="stat-card stat-card--playtime">
+                    <h2 class="stat-card__label">Playtime Timer</h2>
+                    <div class="stat-card__value" id="timer">00:00:00</div>
+                    <p class="stat-card__hint">Live runtime for your current save.</p>
+                </article>
+            </div>
+            <div class="stats-menu__footer">
+                <button id="closeStats" class="statsBtns" type="button">Close</button>
+            </div>
+        </div>
     </div>
 
     <div id="achievementsMenu" class="achievements-menu" style="display: none;">


### PR DESCRIPTION
## Summary
- redesign the statistics modal with a themed panel, drag handle, and stat cards that match the newer menus
- refresh the close button and drag text styles while removing obsolete statistics markup and CSS helpers
- update the drag logic to target the new handle element and keep positioning consistent during drags

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68d5197d7bd08321a70e43244cf75d50