### PR TITLE
Fix rolling history rarity gradients

### DIFF
--- a/files/script.js
+++ b/files/script.js
@@ -11491,13 +11491,16 @@ function updateRollingHistory(title, rarity) {
     historyList.innerHTML = '';
     rollingHistory.forEach((roll) => {
         const listItem = document.createElement('li');
-        listItem.textContent = `${roll.rarity} - ${roll.title}`;
+        const entryText = document.createElement('span');
+        entryText.classList.add('history-entry-text');
+        entryText.textContent = `${roll.rarity} - ${roll.title}`;
 
         const rarityClass = getClassForRarity(roll.rarity);
         if (rarityClass) {
-            listItem.classList.add(rarityClass);
+            entryText.classList.add(rarityClass);
         }
 
+        listItem.appendChild(entryText);
         historyList.appendChild(listItem);
     });
 }

--- a/files/style.css
+++ b/files/style.css
@@ -563,6 +563,10 @@ button:hover::after,
   word-break: break-word;
 }
 
+#historyList li .history-entry-text {
+  display: inline-block;
+}
+
 /* Use the same sheen animation keyframes as the main container */
 @keyframes containerSheen {
   0%   { transform: translateX(-120%); }


### PR DESCRIPTION
## Summary
- wrap rolling history entries in a span so rarity classes can render their text gradients correctly
- add a helper style for the history entry span to support gradient rendering

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68d57fadf7a88321bed93ed27fd15444