### PR TITLE
Fix rolling history rarity gradients

### DIFF
--- a/files/script.js
+++ b/files/script.js
@@ -11491,13 +11491,16 @@ function updateRollingHistory(title, rarity) {
     historyList.innerHTML = '';
     rollingHistory.forEach((roll) => {
         const listItem = document.createElement('li');
-        listItem.textContent = `${roll.rarity} - ${roll.title}`;
+        const entryText = document.createElement('span');
+        entryText.classList.add('history-entry-text');
+        entryText.textContent = `${roll.rarity} - ${roll.title}`;
 
         const rarityClass = getClassForRarity(roll.rarity);
         if (rarityClass) {
-            listItem.classList.add(rarityClass);
+            entryText.classList.add(rarityClass);
         }
 
+        listItem.appendChild(entryText);
         historyList.appendChild(listItem);
     });
 }

--- a/files/style.css
+++ b/files/style.css
@@ -542,11 +542,8 @@ button:hover::after,
 /* History list panel and items */
 #historyList {
   list-style: none;
-  padding: 8px;
+  padding: 0;
   margin: 0;
-  background: linear-gradient(180deg, rgba(255,255,255,0.06), rgba(255,255,255,0.03));
-  border: 1px solid rgba(255,255,255,0.10);
-  border-radius: 12px;
   max-height: 240px;           /* prevent runaway height; scroll if long */
   overflow-y: auto;
 }
@@ -554,13 +551,15 @@ button:hover::after,
 #historyList li {
   font-size: 15px;
   line-height: 1.5;
-  border-radius: 10px;
-  padding: 8px 10px;
-  margin: 6px 4px;
-  background: rgba(255,255,255,0.06);
-  border: 1px solid rgba(255,255,255,0.08);
-  box-shadow: inset 0 1px 0 rgba(255,255,255,0.05);
+  padding: 6px 0;
+  margin: 0;
   word-break: break-word;
+}
+
+#historyList li .history-entry-text {
+  display: inline-block;
+  padding: 4px 6px;
+  border-radius: 8px;
 }
 
 /* Use the same sheen animation keyframes as the main container */


### PR DESCRIPTION
## Summary
- wrap rolling history entries in a span so rarity classes can render their text gradients correctly
- add a helper style for the history entry span to support gradient rendering
- remove the history list panel backgrounds so gradient titles sit directly on the page art

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68d57fadf7a88321bed93ed27fd15444