### PR TITLE
Improve roll display and auto-delete handling

### DIFF
--- a/files/script.js
+++ b/files/script.js
@@ -42,6 +42,11 @@ let rollDisplayHiddenByUser = false;
 let cutsceneHidRollDisplay = false;
 let cutsceneActive = false;
 let cutsceneFailsafeTimeout = null;
+let lastRollPersisted = true;
+let lastRollAutoDeleted = false;
+let lastRollRarityClass = null;
+let allowForcedAudioPlayback = false;
+let pinnedAudioId = null;
 
 const STOPPABLE_AUDIO_IDS = [
   "suspenseAudio",
@@ -149,6 +154,31 @@ const STOPPABLE_AUDIO_IDS = [
   "esteggAudio",
   "isekailofiAudio"
 ];
+
+const STOPPABLE_AUDIO_SET = new Set(STOPPABLE_AUDIO_IDS);
+
+const RARITY_BUCKET_LABELS = {
+  under100: "Basic",
+  under1k: "Decent",
+  under10k: "Grand",
+  under100k: "Mastery",
+  under1m: "Supreme",
+  special: "Special"
+};
+
+const originalAudioPlay = HTMLMediaElement.prototype.play;
+HTMLMediaElement.prototype.play = function (...args) {
+  if (
+    this instanceof HTMLAudioElement &&
+    STOPPABLE_AUDIO_SET.has(this.id) &&
+    !lastRollPersisted &&
+    !allowForcedAudioPlayback
+  ) {
+    return Promise.resolve();
+  }
+
+  return originalAudioPlay.apply(this, args);
+};
 
 function setRollButtonEnabled(enabled) {
   const button = document.getElementById("rollButton");
@@ -615,8 +645,31 @@ function resetAudioState(audio, id) {
   }
 }
 
-function stopAllAudio() {
+function stopAllAudio(options = {}) {
+  const preserveIds = new Set();
+
+  if (options) {
+    const { preservePinned = false, preserve = null } = options;
+    if (preservePinned && pinnedAudioId) {
+      preserveIds.add(pinnedAudioId);
+    }
+
+    if (typeof preserve === "string") {
+      preserveIds.add(preserve);
+    } else if (Array.isArray(preserve)) {
+      preserve.forEach((id) => {
+        if (id) {
+          preserveIds.add(id);
+        }
+      });
+    }
+  }
+
   STOPPABLE_AUDIO_IDS.forEach((id) => {
+    if (preserveIds.has(id)) {
+      return;
+    }
+
     const audio = getAudioElement(id);
     if (!audio) {
       return;
@@ -861,7 +914,7 @@ document.getElementById("rollButton").addEventListener("click", function () {
     rollCount++;
   }
 
-  stopAllAudio();
+  stopAllAudio({ preservePinned: true });
 
   let rarity = rollRarity();
   let title = selectTitle(rarity);
@@ -8967,6 +9020,11 @@ toggleCutscene1MBtn.addEventListener("click", function () {
 });
 
 function rollRarity() {
+  lastRollPersisted = true;
+  lastRollAutoDeleted = false;
+  lastRollRarityClass = null;
+  allowForcedAudioPlayback = false;
+
   const rarities = [
     {
       type: "Common [1 in 2.5]",
@@ -9644,25 +9702,16 @@ function selectTitle(rarity) {
   return titles[Math.floor(Math.random() * titles.length)];
 }
 
-function displayResult(title, rarity) {
-  const resultDiv = document.getElementById("result");
-  resultDiv.innerText = `You rolled a ${rarity}
-    Item: ${title}!`;
-}
-
-function changeBackground(rarityClass) {
-  const body = document.body;
-  body.className = "";
-  body.classList.add(rarityClass);
-}
-
 function addToInventory(title, rarityClass) {
+  lastRollRarityClass = rarityClass || null;
   const rolledAt = typeof rollCount === "number"
     ? rollCount
     : parseInt(localStorage.getItem("rollCount")) || 0;
   const autoDeleteSet = getAutoDeleteSet();
   const bucket = normalizeRarityBucket(rarityClass);
   if (autoDeleteSet.has(bucket)) {
+    lastRollPersisted = false;
+    lastRollAutoDeleted = true;
     showStatusMessage(`${title} auto-deleted`, 800);
     return false; // not persisted
   }
@@ -9671,14 +9720,92 @@ function addToInventory(title, rarityClass) {
 
   for (const category in rarityCategories) {
     if (excludedRarities.has(category) && rarityCategories[category].includes(rarityClass)) {
-      return;
+      lastRollPersisted = false;
+      lastRollAutoDeleted = true;
+      return false;
     }
   }
 
   inventory.push({ title, rarityClass, rolledAt });
   localStorage.setItem("inventory", JSON.stringify(inventory));
   renderInventory();
+  lastRollPersisted = true;
+  lastRollAutoDeleted = false;
   return true; // persisted
+}
+
+function displayResult(title, rarity) {
+  const resultDiv = document.getElementById("result");
+  if (!resultDiv) {
+    return;
+  }
+
+  const rarityValue = rarity == null ? "" : rarity;
+  const rarityText = typeof rarityValue === "string" ? rarityValue : String(rarityValue);
+  const [rarityName, oddsRaw] = rarityText.split(" [");
+  const odds = oddsRaw ? oddsRaw.replace(/\]$/, "") : "";
+  const bucket = normalizeRarityBucket(lastRollRarityClass);
+  const bucketClass = bucket ? `roll-result-card--${bucket}` : "";
+  const bucketLabel = bucket ? (RARITY_BUCKET_LABELS[bucket] || bucket) : "";
+  const labelClass = getLabelClassForRarity(lastRollRarityClass, bucket);
+
+  const card = document.createElement("div");
+  card.className = "roll-result-card";
+  if (bucketClass) {
+    card.classList.add(bucketClass);
+  }
+  if (lastRollAutoDeleted) {
+    card.classList.add("roll-result-card--skipped");
+  }
+
+  const header = document.createElement("div");
+  header.className = "roll-result-card__header";
+
+  const rarityLabel = document.createElement("span");
+  rarityLabel.className = "roll-result-card__rarity";
+  if (labelClass) {
+    rarityLabel.classList.add(labelClass);
+  }
+  rarityLabel.textContent = (rarityName || rarityText || "Unknown").trim();
+  header.appendChild(rarityLabel);
+
+  if (odds) {
+    const oddsEl = document.createElement("span");
+    oddsEl.className = "roll-result-card__odds";
+    oddsEl.textContent = odds;
+    header.appendChild(oddsEl);
+  }
+
+  const badge = document.createElement("span");
+  badge.className = "roll-result-card__badge";
+  badge.textContent = lastRollAutoDeleted ? "Skipped" : "New Title";
+  header.appendChild(badge);
+
+  const titleEl = document.createElement("div");
+  titleEl.className = "roll-result-card__title";
+  titleEl.textContent = title || "Unknown";
+
+  const statusEl = document.createElement("div");
+  statusEl.className = "roll-result-card__status";
+  if (lastRollAutoDeleted) {
+    statusEl.textContent = bucketLabel
+      ? `Auto-deleted (${bucketLabel})`
+      : "Auto-deleted";
+    statusEl.classList.add("roll-result-card__status--skipped");
+  } else {
+    statusEl.textContent = "Added to inventory";
+  }
+
+  card.appendChild(header);
+  card.appendChild(titleEl);
+  card.appendChild(statusEl);
+
+  resultDiv.innerHTML = "";
+  resultDiv.appendChild(card);
+
+  requestAnimationFrame(() => {
+    card.classList.add("is-visible");
+  });
 }
 
 function getAutoDeleteSet() {
@@ -10254,7 +10381,7 @@ function equipItem(item) {
 }
 
 function handleEquippedItem(item) {
-  changeBackground(item.rarityClass, item.title);
+  changeBackground(item.rarityClass, item.title, { force: true });
 }
 
 function updatePagination() {
@@ -12275,58 +12402,85 @@ function ensureBgStack() {
   }
 }
 
-function changeBackground(rarityClass, itemTitle) {
-  if (!isChangeEnabled) return;
+function changeBackground(rarityClass, itemTitle, options = {}) {
+  const force = typeof options === "object" && options !== null
+    ? Boolean(options.force)
+    : Boolean(options);
+
+  if (!force && (!isChangeEnabled || !lastRollPersisted)) {
+    return;
+  }
 
   const details = backgroundDetails[rarityClass];
   if (!details) return;
 
-  // Update the body class so existing rarity-based styling keeps working.
-  if (__currentBgClass !== rarityClass) {
-    if (__currentBgClass) {
-      document.body.classList.remove(__currentBgClass);
-    }
-    document.body.classList.add(rarityClass);
-    __currentBgClass = rarityClass;
-  }
-
-  // Prepare the stack
-  ensureBgStack();
-
-  // Determine next layer and set its image
-  const nextLayer = __bgActive === 0 ? __bgLayerB : __bgLayerA;
-  const currLayer = __bgActive === 0 ? __bgLayerA : __bgLayerB;
-
-  // Point to the file URL (string or template is ok)
-  nextLayer.style.backgroundImage = `url(${details.image})`;
-
-  const bucket = normalizeRarityBucket(rarityClass);
-  triggerScreenShakeByBucket(bucket);
-
-  // Trigger the crossfade on the next animation frame to ensure style is applied
-  requestAnimationFrame(() => {
-    // Bring the next one in, send the current one out
-    nextLayer.classList.add("is-active");
-    currLayer.classList.remove("is-active");
-    __bgActive = __bgActive === 0 ? 1 : 0;
-  });
-
-  // Maintain your audio behavior
-  if (currentAudio) {
-    currentAudio.pause();
-    currentAudio.currentTime = 0;
-  }
-  if (details.audio) {
-    const newAudio = document.getElementById(details.audio);
-    if (newAudio) {
-      newAudio.play();
-      currentAudio = newAudio;
-    }
+  if (force) {
+    pinnedAudioId = details.audio || null;
   } else {
-    currentAudio = null;
+    pinnedAudioId = null;
   }
 
-  // Clear direct body background inline style so the stack is the only visual source.
-  // This prevents flicker if some other code set document.body.style.backgroundImage.
-  document.body.style.backgroundImage = "";
+  const previousForcedState = allowForcedAudioPlayback;
+  if (force) {
+    allowForcedAudioPlayback = true;
+  }
+
+  try {
+    // Update the body class so existing rarity-based styling keeps working.
+    if (__currentBgClass !== rarityClass) {
+      if (__currentBgClass) {
+        document.body.classList.remove(__currentBgClass);
+      }
+      document.body.classList.add(rarityClass);
+      __currentBgClass = rarityClass;
+    }
+
+    // Prepare the stack
+    ensureBgStack();
+
+    // Determine next layer and set its image
+    const nextLayer = __bgActive === 0 ? __bgLayerB : __bgLayerA;
+    const currLayer = __bgActive === 0 ? __bgLayerA : __bgLayerB;
+
+    // Point to the file URL (string or template is ok)
+    nextLayer.style.backgroundImage = `url(${details.image})`;
+
+    const bucket = normalizeRarityBucket(rarityClass);
+    triggerScreenShakeByBucket(bucket);
+
+    // Trigger the crossfade on the next animation frame to ensure style is applied
+    requestAnimationFrame(() => {
+      // Bring the next one in, send the current one out
+      nextLayer.classList.add("is-active");
+      currLayer.classList.remove("is-active");
+      __bgActive = __bgActive === 0 ? 1 : 0;
+    });
+
+    // Maintain your audio behavior
+    if (currentAudio) {
+      currentAudio.pause();
+      currentAudio.currentTime = 0;
+    }
+    if (details.audio) {
+      const newAudio = document.getElementById(details.audio);
+      if (newAudio) {
+        newAudio.volume = typeof audioVolume === "number" ? audioVolume : 1;
+        const playPromise = newAudio.play();
+        if (playPromise && typeof playPromise.catch === "function") {
+          playPromise.catch(() => {});
+        }
+        currentAudio = newAudio;
+      }
+    } else {
+      currentAudio = null;
+    }
+
+    // Clear direct body background inline style so the stack is the only visual source.
+    // This prevents flicker if some other code set document.body.style.backgroundImage.
+    document.body.style.backgroundImage = "";
+  } finally {
+    if (force) {
+      allowForcedAudioPlayback = previousForcedState;
+    }
+  }
 }

--- a/files/style.css
+++ b/files/style.css
@@ -750,18 +750,168 @@ body {
   transform: translateX(0%);
 }
 
-/* Result display chip */
+/* Result display panel */
 .container .res {
-  min-height: 36px;
-  padding: 6px 12px;
-  border-radius: 10px;
-  color: #fff;
-  font-weight: 700;
-  letter-spacing: 0.4px;
+  width: 100%;
+  min-height: 110px;
+  padding: 12px 6px 16px;
+  display: flex;
+  justify-content: center;
+  align-items: stretch;
+}
 
-  background: linear-gradient(180deg, rgba(255,255,255,0.16), rgba(255,255,255,0.08));
-  border: 1px solid rgba(255,255,255,0.10);
-  box-shadow: inset 0 1px 0 rgba(255,255,255,0.08);
+.roll-result-card {
+  position: relative;
+  width: min(100%, 440px);
+  padding: 20px 24px 22px;
+  border-radius: 18px;
+  color: #f6f8ff;
+  background: linear-gradient(165deg, rgba(28,32,52,0.88), rgba(16,18,28,0.86));
+  border: 1px solid rgba(255,255,255,0.18);
+  box-shadow: 0 16px 38px rgba(4,9,30,0.45), inset 0 1px 0 rgba(255,255,255,0.12);
+  overflow: hidden;
+  isolation: isolate;
+  opacity: 0;
+  transform: translateY(14px) scale(0.97);
+  transition: opacity 240ms ease, transform 280ms cubic-bezier(.16,.78,.32,1.18);
+  --roll-card-accent: linear-gradient(140deg, rgba(122,162,255,0.7), rgba(134,96,255,0.45));
+}
+
+.roll-result-card::before {
+  content: "";
+  position: absolute;
+  inset: -1px;
+  border-radius: 18px;
+  background: var(--roll-card-accent);
+  opacity: 0.55;
+  mix-blend-mode: screen;
+  pointer-events: none;
+  z-index: -2;
+}
+
+.roll-result-card::after {
+  content: "";
+  position: absolute;
+  inset: 0;
+  border-radius: 18px;
+  background: radial-gradient(120% 140% at 25% 0%, rgba(255,255,255,0.28), transparent 60%);
+  pointer-events: none;
+  z-index: -1;
+}
+
+.roll-result-card.is-visible {
+  opacity: 1;
+  transform: translateY(0) scale(1);
+}
+
+.roll-result-card__header {
+  display: flex;
+  align-items: baseline;
+  justify-content: flex-start;
+  flex-wrap: wrap;
+  gap: 10px;
+  margin-bottom: 12px;
+}
+
+.roll-result-card__rarity {
+  font-size: 0.95rem;
+  letter-spacing: 0.14em;
+  text-transform: uppercase;
+  font-weight: 700;
+}
+
+.roll-result-card__odds {
+  font-size: 0.72rem;
+  letter-spacing: 0.18em;
+  text-transform: uppercase;
+  color: rgba(224,230,255,0.68);
+  white-space: nowrap;
+}
+
+.roll-result-card__badge {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  margin-left: auto;
+  padding: 4px 12px;
+  border-radius: 999px;
+  font-size: 0.68rem;
+  letter-spacing: 0.18em;
+  text-transform: uppercase;
+  background: rgba(255,255,255,0.12);
+  border: 1px solid rgba(255,255,255,0.28);
+  color: rgba(245,248,255,0.86);
+  box-shadow: inset 0 1px 0 rgba(255,255,255,0.2);
+}
+
+.roll-result-card__title {
+  font-size: clamp(1.28rem, 3.2vw, 1.7rem);
+  font-weight: 800;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  margin-bottom: 6px;
+}
+
+.roll-result-card__status {
+  font-size: 0.78rem;
+  letter-spacing: 0.2em;
+  text-transform: uppercase;
+  color: rgba(214,224,255,0.74);
+}
+
+.roll-result-card__status--skipped {
+  color: #ffb6c1;
+}
+
+.roll-result-card--skipped {
+  --roll-card-accent: linear-gradient(135deg, rgba(255,120,136,0.48), rgba(255,99,132,0.36));
+  background: linear-gradient(165deg, rgba(44,18,26,0.9), rgba(22,10,16,0.92));
+}
+
+.roll-result-card--skipped .roll-result-card__badge {
+  background: rgba(255,105,132,0.14);
+  border-color: rgba(255,142,164,0.45);
+  color: #ffced9;
+}
+
+.roll-result-card--under100 {
+  --roll-card-accent: linear-gradient(135deg, rgba(116,196,255,0.6), rgba(60,137,255,0.52));
+}
+
+.roll-result-card--under1k {
+  --roll-card-accent: linear-gradient(135deg, rgba(118,255,214,0.6), rgba(44,186,142,0.5));
+}
+
+.roll-result-card--under10k {
+  --roll-card-accent: linear-gradient(135deg, rgba(255,208,140,0.6), rgba(255,153,51,0.5));
+}
+
+.roll-result-card--under100k {
+  --roll-card-accent: linear-gradient(135deg, rgba(200,158,255,0.62), rgba(132,76,255,0.5));
+}
+
+.roll-result-card--under1m {
+  --roll-card-accent: linear-gradient(135deg, rgba(255,144,220,0.6), rgba(178,96,255,0.5));
+}
+
+.roll-result-card--special {
+  --roll-card-accent: linear-gradient(135deg, rgba(255,243,173,0.62), rgba(255,206,109,0.52));
+}
+
+@media (max-width: 520px) {
+  .roll-result-card {
+    padding: 18px 18px 20px;
+  }
+
+  .roll-result-card__header {
+    gap: 8px;
+  }
+
+  .roll-result-card__badge {
+    width: 100%;
+    margin-left: 0;
+    margin-top: 2px;
+  }
 }
 
 /* Compact screens */
@@ -781,6 +931,9 @@ body {
     transition: none !important;
   }
   .container .rButton {
+    transition: none !important;
+  }
+  .roll-result-card {
     transition: none !important;
   }
 }


### PR DESCRIPTION
## Summary
- restyle the roll result panel to present rarity, odds, and status in a richer card layout
- track roll persistence state so auto-deleted titles no longer change backgrounds or trigger new audio
- add audio playback guards and force overrides for manual equips to keep existing ambience intact
- preserve manually equipped ambience when starting new rolls by skipping the global audio reset for that track

## Testing
- No automated tests were run (not available)

------
https://chatgpt.com/codex/tasks/task_e_68d5a017f86883219874ffcb1e9dfe69