### PR TITLE
Delay asset loading until start and fix sticky headers

### DIFF
--- a/files/script.js
+++ b/files/script.js
@@ -36,7 +36,6 @@ let audioVolume = 1;
 let isMuted = false;
 let previousVolume = audioVolume;
 let refreshTimeout;
-let hasScheduledLoad = false;
 let skipCutscene1K = true;
 let skipCutscene10K = true;
 let skipCutscene100K = true;
@@ -55,6 +54,15 @@ let pausedEquippedAudioState = null;
 let resumeEquippedAudioAfterCutscene = false;
 let pendingCutsceneRarity = null;
 const rolledRarityBuckets = new Set(storage.get("rolledRarityBuckets", []));
+
+let postStartInitialized = false;
+let audioSliderElement = null;
+let audioSliderValueLabelElement = null;
+let muteButtonElement = null;
+let heartContainerElement = null;
+let heartIntervalId = null;
+let playTimeIntervalId = null;
+let autoRollButtonElement = null;
 
 const STOPPABLE_AUDIO_IDS = [
   "suspenseAudio",
@@ -478,6 +486,31 @@ async function runInitialLoadSequence(onProgress) {
 
   report("Ready!");
   await wait(180);
+}
+
+function initializeAfterStart() {
+  if (postStartInitialized) {
+    return;
+  }
+
+  postStartInitialized = true;
+
+  registerRollButtonHandler();
+  registerCutsceneToggleButtons();
+  registerDeleteAllButton();
+  registerInterfaceToggleButtons();
+  registerMenuButtons();
+  registerResponsiveHandlers();
+  registerMenuDragHandlers();
+  enhanceInventoryDeleteButtons();
+  setupAudioControls();
+  initializeAutoRollControls();
+  initializeHeartEffect();
+  registerDataPersistenceButtons();
+  initializePlayTimeTracker();
+  registerRarityDeletionButtons();
+  scheduleAllCooldownButtons();
+  updateAchievementsList();
 }
 
 const CUTSCENE_SKIP_SETTINGS = [
@@ -953,6 +986,14 @@ document.addEventListener("DOMContentLoaded", () => {
 
     try {
       if (typeof mainAudio !== "undefined" && mainAudio && typeof mainAudio.play === "function") {
+        if (mainAudio.preload === "none") {
+          mainAudio.preload = "auto";
+          try {
+            mainAudio.load();
+          } catch (error) {
+            /* no-op */
+          }
+        }
         // Kick off playback without awaiting so UI initialisation continues even if the
         // browser delays or blocks autoplay.
         const playAttempt = mainAudio.play();
@@ -1002,22 +1043,10 @@ document.addEventListener("DOMContentLoaded", () => {
     if (rollButton) {
       rollButton.disabled = false;
     }
+
+    initializeAfterStart();
   });
 });
-
-function loadContent() {
-  LOADING_SEQUENCE.forEach(({ action }) => action());
-}
-
-function load() {
-  if (document.readyState === "loading" && !hasScheduledLoad) {
-    hasScheduledLoad = true;
-    document.addEventListener("DOMContentLoaded", () => {
-      hasScheduledLoad = false;
-      loadContent();
-    }, { once: true });
-  }
-}
 
 function loadCutsceneSkip() {
   CUTSCENE_SKIP_SETTINGS.forEach(({ key, labelId, label }) => {
@@ -1140,9 +1169,13 @@ function updateAchievementsList() {
   });
 }
 
-document.addEventListener("DOMContentLoaded", updateAchievementsList);
+function registerRollButtonHandler() {
+  const rollButtonElement = document.getElementById("rollButton");
+  if (!rollButtonElement) {
+    return;
+  }
 
-document.getElementById("rollButton").addEventListener("click", function () {
+  rollButtonElement.addEventListener("click", function () {
   const rollButton = byId("rollButton");
   if (!rollButton) {
     return;
@@ -9250,43 +9283,54 @@ document.getElementById("rollButton").addEventListener("click", function () {
   localStorage.setItem("rollCount", rollCount);
   localStorage.setItem("rollCount1", rollCount1);
   load();
-});
+  });
+}
 
-const toggleCutscene1KBtn = document.getElementById("toggleCutscene1K");
-const toggleCutscene1KTxt = document.getElementById("1KTxt");
-toggleCutscene1KBtn.addEventListener("click", function () {
-  skipCutscene1K = !skipCutscene1K;
-  console.log(`Cutscene skip for 1K has been set to ${skipCutscene1K}`);
-  localStorage.setItem('skipCutscene1K', JSON.stringify(skipCutscene1K));
-  toggleCutscene1KTxt.textContent = `Skip Decent Cutscenes ${skipCutscene1K ? "" : "On"}`;
-});
+function registerCutsceneToggleButtons() {
+  const toggleCutscene1KBtn = document.getElementById("toggleCutscene1K");
+  const toggleCutscene1KTxt = document.getElementById("1KTxt");
+  if (toggleCutscene1KBtn && toggleCutscene1KTxt) {
+    toggleCutscene1KBtn.addEventListener("click", function () {
+      skipCutscene1K = !skipCutscene1K;
+      console.log(`Cutscene skip for 1K has been set to ${skipCutscene1K}`);
+      localStorage.setItem("skipCutscene1K", JSON.stringify(skipCutscene1K));
+      toggleCutscene1KTxt.textContent = `Skip Decent Cutscenes ${skipCutscene1K ? "" : "On"}`;
+    });
+  }
 
-const toggleCutscene10KBtn = document.getElementById("toggleCutscene10K");
-const toggleCutscene10KTxt = document.getElementById("10KTxt");
-toggleCutscene10KBtn.addEventListener("click", function () {
-  skipCutscene10K = !skipCutscene10K;
-  console.log(`Cutscene skip for 10K has been set to ${skipCutscene10K}`);
-  localStorage.setItem('skipCutscene10K', JSON.stringify(skipCutscene10K));
-  toggleCutscene10KTxt.textContent = `Skip Grand Cutscenes ${skipCutscene10K ? "" : "On"}`;
-});
+  const toggleCutscene10KBtn = document.getElementById("toggleCutscene10K");
+  const toggleCutscene10KTxt = document.getElementById("10KTxt");
+  if (toggleCutscene10KBtn && toggleCutscene10KTxt) {
+    toggleCutscene10KBtn.addEventListener("click", function () {
+      skipCutscene10K = !skipCutscene10K;
+      console.log(`Cutscene skip for 10K has been set to ${skipCutscene10K}`);
+      localStorage.setItem("skipCutscene10K", JSON.stringify(skipCutscene10K));
+      toggleCutscene10KTxt.textContent = `Skip Grand Cutscenes ${skipCutscene10K ? "" : "On"}`;
+    });
+  }
 
-const toggleCutscene100KBtn = document.getElementById("toggleCutscene100K");
-const toggleCutscene100KTxt = document.getElementById("100KTxt");
-toggleCutscene100KBtn.addEventListener("click", function () {
-  skipCutscene100K = !skipCutscene100K;
-  console.log(`Cutscene skip for 100K has been set to ${skipCutscene100K}`);
-  localStorage.setItem('skipCutscene100K', JSON.stringify(skipCutscene100K));
-  toggleCutscene100KTxt.textContent = `Skip Mastery Cutscenes ${skipCutscene100K ? "" : "On"}`;
-});
+  const toggleCutscene100KBtn = document.getElementById("toggleCutscene100K");
+  const toggleCutscene100KTxt = document.getElementById("100KTxt");
+  if (toggleCutscene100KBtn && toggleCutscene100KTxt) {
+    toggleCutscene100KBtn.addEventListener("click", function () {
+      skipCutscene100K = !skipCutscene100K;
+      console.log(`Cutscene skip for 100K has been set to ${skipCutscene100K}`);
+      localStorage.setItem("skipCutscene100K", JSON.stringify(skipCutscene100K));
+      toggleCutscene100KTxt.textContent = `Skip Mastery Cutscenes ${skipCutscene100K ? "" : "On"}`;
+    });
+  }
 
-const toggleCutscene1MBtn = document.getElementById("toggleCutscene1M");
-const toggleCutscene1MTxt = document.getElementById("1MTxt");
-toggleCutscene1MBtn.addEventListener("click", function () {
-  skipCutscene1M = !skipCutscene1M;
-  console.log(`Cutscene skip for 1M has been set to ${skipCutscene1M}`);
-  localStorage.setItem('skipCutscene1M', JSON.stringify(skipCutscene1M));
-  toggleCutscene1MTxt.textContent = `Skip Supreme Cutscenes ${skipCutscene1M ? "" : "On"}`;
-});
+  const toggleCutscene1MBtn = document.getElementById("toggleCutscene1M");
+  const toggleCutscene1MTxt = document.getElementById("1MTxt");
+  if (toggleCutscene1MBtn && toggleCutscene1MTxt) {
+    toggleCutscene1MBtn.addEventListener("click", function () {
+      skipCutscene1M = !skipCutscene1M;
+      console.log(`Cutscene skip for 1M has been set to ${skipCutscene1M}`);
+      localStorage.setItem("skipCutscene1M", JSON.stringify(skipCutscene1M));
+      toggleCutscene1MTxt.textContent = `Skip Supreme Cutscenes ${skipCutscene1M ? "" : "On"}`;
+    });
+  }
+}
 
 function rollRarity() {
   lastRollPersisted = true;
@@ -10197,124 +10241,151 @@ function deleteAllByRarity(rarityClass) {
   renderInventory();
 }
 
-document
-  .getElementById("toggleInventoryBtn")
-  .addEventListener("click", function () {
-    const inventorySection = document.querySelector(".inventory");
-    const isVisible = inventorySection.style.visibility !== "visible";
+function registerInterfaceToggleButtons() {
+  const toggleInventoryBtn = document.getElementById("toggleInventoryBtn");
+  if (toggleInventoryBtn) {
+    toggleInventoryBtn.addEventListener("click", function () {
+      const inventorySection = document.querySelector(".inventory");
+      if (!inventorySection) {
+        return;
+      }
 
-    if (isVisible) {
-      inventorySection.style.visibility = "visible";
-      this.textContent = "Hide Inventory";
-    } else {
-      inventorySection.style.visibility = "hidden";
-      this.textContent = "Show Inventory";
-    }
-  });
+      const isVisible = inventorySection.style.visibility !== "visible";
 
-const toggleUiBtn = document.getElementById("toggleUiBtn");
-const uiSection = document.querySelector(".ui");
-
-toggleUiBtn.addEventListener("click", function (event) {
-  const isVisible = uiSection.style.visibility !== "hidden";
-
-  if (isVisible) {
-    uiSection.style.visibility = "hidden";
-    this.textContent = "Show UI";
-  } else {
-    uiSection.style.visibility = "visible";
-    this.textContent = "Hide UI";
+      if (isVisible) {
+        inventorySection.style.visibility = "visible";
+        this.textContent = "Hide Inventory";
+      } else {
+        inventorySection.style.visibility = "hidden";
+        this.textContent = "Show Inventory";
+      }
+    });
   }
 
-  if (this.textContent === "Show UI") {
-    toggleUiBtn.style.display = "none";
-    event.stopPropagation();
+  const toggleUiBtn = document.getElementById("toggleUiBtn");
+  const uiSection = document.querySelector(".ui");
+
+  if (toggleUiBtn && uiSection) {
+    toggleUiBtn.addEventListener("click", function (event) {
+      const isVisible = uiSection.style.visibility !== "hidden";
+
+      if (isVisible) {
+        uiSection.style.visibility = "hidden";
+        this.textContent = "Show UI";
+      } else {
+        uiSection.style.visibility = "visible";
+        this.textContent = "Hide UI";
+      }
+
+      if (this.textContent === "Show UI") {
+        toggleUiBtn.style.display = "none";
+        event.stopPropagation();
+      }
+    });
+
+    document.addEventListener("click", () => {
+      if (toggleUiBtn.style.display === "none") {
+        toggleUiBtn.style.display = "block";
+      }
+    });
   }
-});
 
-document.addEventListener("click", () => {
-  if (toggleUiBtn.style.display === "none") {
-    toggleUiBtn.style.display = "block";
+  const toggleRollDisplayBtn = document.getElementById("toggleRollDisplayBtn");
+  if (toggleRollDisplayBtn) {
+    toggleRollDisplayBtn.addEventListener("click", function () {
+      const inventorySection = document.querySelector(".container");
+      if (!inventorySection) {
+        return;
+      }
+
+      const isVisible = inventorySection.style.visibility !== "hidden";
+
+      if (isVisible) {
+        inventorySection.style.visibility = "hidden";
+        rollDisplayHiddenByUser = true;
+        this.textContent = "Show Roll & Display";
+      } else {
+        inventorySection.style.visibility = "visible";
+        rollDisplayHiddenByUser = false;
+        cutsceneHidRollDisplay = false;
+        this.textContent = "Hide Roll & Display";
+      }
+    });
   }
-});
 
-document
-  .getElementById("toggleRollDisplayBtn")
-  .addEventListener("click", function () {
-    const inventorySection = document.querySelector(".container");
-    const isVisible = inventorySection.style.visibility !== "hidden";
+  const toggleRollHistoryBtn = document.getElementById("toggleRollHistoryBtn");
+  if (toggleRollHistoryBtn) {
+    toggleRollHistoryBtn.addEventListener("click", function () {
+      const historySection = document.querySelector(".historySection");
+      const container = document.querySelector(".container1");
+      if (!historySection || !container) {
+        return;
+      }
 
-    if (isVisible) {
-      inventorySection.style.visibility = "hidden";
-      rollDisplayHiddenByUser = true;
-      this.textContent = "Show Roll & Display";
-    } else {
-      inventorySection.style.visibility = "visible";
-      rollDisplayHiddenByUser = false;
-      cutsceneHidRollDisplay = false;
-      this.textContent = "Hide Roll & Display";
-    }
-  });
+      const isVisible = historySection.style.visibility !== "hidden";
 
-window.addEventListener("resize", function () {
-  const container = document.querySelector(".container1");
-  const inventory = document.querySelector(".inventory");
-  const SeButton = document.getElementById("settingsButton");
-  const AButton = document.getElementById("achievementsButton");
-  const StButton = document.getElementById("statsButton");
-  const sliderContainer = document.querySelector(".slider-container");
-  const originalParent = document.querySelector(".original-parent");
-
-  if (window.innerWidth < 821) {
-    SeButton.style.display = "none";
-    AButton.style.display = "none";
-    StButton.style.display = "none";
-    container.style.left = "10px";
-    inventory.style.height = "58vh";
-    inventory.style.width = "42vh";
-
-    if (!container.contains(sliderContainer)) {
-      container.appendChild(sliderContainer);
-    }
-  } else if (window.innerWidth > 821 && window.innerHeight > 1400) { 
-    // Fix: Use '&&' instead of '&'
-    inventory.style.width = "70vh";
-    container.style.left = "383px";
-
-    if (originalParent && !originalParent.contains(sliderContainer)) {
-      originalParent.appendChild(sliderContainer);
-    }
-  } else {
-    container.style.left = "383px";
-    SeButton.style.display = "inline-block";
-    AButton.style.display = "inline-block";
-    StButton.style.display = "inline-block";
-    inventory.style.width = "60vh";
-    inventory.style.height = "85vh";
-
-    if (originalParent && !originalParent.contains(sliderContainer)) {
-      originalParent.appendChild(sliderContainer);
-    }
+      if (isVisible) {
+        historySection.style.visibility = "hidden";
+        this.textContent = "Show Roll History";
+        container.style.left = "10px";
+      } else {
+        historySection.style.visibility = "visible";
+        this.textContent = "Hide Roll History";
+        container.style.left = "383px";
+      }
+    });
   }
-});
+}
 
-document
-  .getElementById("toggleRollHistoryBtn")
-  .addEventListener("click", function () {
-    const historySection = document.querySelector(".historySection");
+function registerResponsiveHandlers() {
+  const applyLayout = () => {
     const container = document.querySelector(".container1");
-    const isVisible = historySection.style.visibility !== "hidden";
+    const inventory = document.querySelector(".inventory");
+    const settingsButton = document.getElementById("settingsButton");
+    const achievementsButton = document.getElementById("achievementsButton");
+    const statsButton = document.getElementById("statsButton");
+    const sliderContainer = document.querySelector(".slider-container");
+    const originalParent = document.querySelector(".original-parent");
 
-    if (isVisible) {
-      historySection.style.visibility = "hidden";
-      this.textContent = "Show Roll History";
-      container.style.left = "10px";
-    } else {
-      historySection.style.visibility = "visible";
-      this.textContent = "Hide Roll History";
-      container.style.left = "383px";
+    if (!container || !inventory || !settingsButton || !achievementsButton || !statsButton) {
+      return;
     }
-});
+
+    if (window.innerWidth < 821) {
+      settingsButton.style.display = "none";
+      achievementsButton.style.display = "none";
+      statsButton.style.display = "none";
+      container.style.left = "10px";
+      inventory.style.height = "58vh";
+      inventory.style.width = "42vh";
+
+      if (sliderContainer && !container.contains(sliderContainer)) {
+        container.appendChild(sliderContainer);
+      }
+    } else if (window.innerWidth > 821 && window.innerHeight > 1400) {
+      inventory.style.width = "70vh";
+      container.style.left = "383px";
+
+      if (originalParent && sliderContainer && !originalParent.contains(sliderContainer)) {
+        originalParent.appendChild(sliderContainer);
+      }
+    } else {
+      container.style.left = "383px";
+      settingsButton.style.display = "inline-block";
+      achievementsButton.style.display = "inline-block";
+      statsButton.style.display = "inline-block";
+      inventory.style.width = "60vh";
+      inventory.style.height = "85vh";
+
+      if (originalParent && sliderContainer && !originalParent.contains(sliderContainer)) {
+        originalParent.appendChild(sliderContainer);
+      }
+    }
+  };
+
+  applyLayout();
+  window.addEventListener("resize", applyLayout);
+}
 
 const backgroundDetails = {
   menuDefault: { image: "files/backgrounds/menu.png", audio: null },
@@ -10877,18 +10948,19 @@ function toggleFullscreen() {
   }
 }
 
-document.addEventListener("DOMContentLoaded", (event) => {
-  document
-    .getElementById("deleteAllButton")
-    .addEventListener("click", function () {
-      var confirmDelete = confirm(
-        "Are you sure you want to delete all Titles?"
-      );
-      if (confirmDelete) {
-        deleteAllFromInventory();
-      }
-    });
-});
+function registerDeleteAllButton() {
+  const deleteAllButton = document.getElementById("deleteAllButton");
+  if (!deleteAllButton) {
+    return;
+  }
+
+  deleteAllButton.addEventListener("click", function () {
+    const confirmDelete = confirm("Are you sure you want to delete all Titles?");
+    if (confirmDelete) {
+      deleteAllFromInventory();
+    }
+  });
+}
 
 function startAnimation() {
   const star = document.getElementById("star");
@@ -11535,9 +11607,7 @@ function scheduleAllCooldownButtons() {
   });
 }
 
-scheduleAllCooldownButtons();
-
-document.addEventListener("DOMContentLoaded", () => {
+function registerMenuDragHandlers() {
   const settingsMenu = document.getElementById("settingsMenu");
   const settingsHeader = settingsMenu?.querySelector(".settings-header");
   const settingsBody = settingsMenu?.querySelector(".settings-body");
@@ -11547,7 +11617,7 @@ document.addEventListener("DOMContentLoaded", () => {
   const statsMenu = document.getElementById("statsMenu");
   const statsHeader = statsMenu?.querySelector(".stats-header");
   const statsDragHandle = statsMenu?.querySelector(".stats-menu__drag-handle");
-  const headerStats = statsMenu.querySelector("h3");
+  const headerStats = statsMenu?.querySelector("h3");
   let isDraggingSettings = false;
   let isDraggingAchievements = false;
   let isDraggingStats = false;
@@ -11560,7 +11630,7 @@ document.addEventListener("DOMContentLoaded", () => {
   let offsetXStyle = 0;
   let offsetYStyle = 0;
 
-  if (settingsHeader) {
+  if (settingsHeader && settingsMenu) {
     settingsHeader.addEventListener("mousedown", (event) => {
       if (event.button !== 0 || event.target.closest(".settings-close-btn")) {
         return;
@@ -11595,7 +11665,7 @@ document.addEventListener("DOMContentLoaded", () => {
     });
   }
 
-  if (achievementsHeader) {
+  if (achievementsHeader && achievementsMenu) {
     achievementsHeader.addEventListener("mousedown", (event) => {
       if (event.button !== 0 || event.target.closest(".achievements-close-btn")) {
         return;
@@ -11632,7 +11702,7 @@ document.addEventListener("DOMContentLoaded", () => {
     });
   }
 
-  if (headerStats) {
+  if (headerStats && statsDragHandle) {
     headerStats.addEventListener("mousedown", (event) => {
       isDraggingStats = true;
       statsDragHandle.classList.add("is-dragging");
@@ -11671,12 +11741,12 @@ document.addEventListener("DOMContentLoaded", () => {
   }
 
   document.addEventListener("mousemove", (event) => {
-    if (isDraggingSettings) {
+    if (isDraggingSettings && settingsMenu) {
       settingsMenu.style.left = `${event.clientX - offsetX}px`;
       settingsMenu.style.top = `${event.clientY - offsetY}px`;
     }
 
-    if (isDraggingAchievements) {
+    if (isDraggingAchievements && achievementsMenu) {
       achievementsMenu.style.left = `${event.clientX - offsetXAchievements}px`;
       achievementsMenu.style.top = `${event.clientY - offsetYAchievements}px`;
     }
@@ -11701,11 +11771,12 @@ document.addEventListener("DOMContentLoaded", () => {
     if (isDraggingStats) {
       isDraggingStats = false;
       statsHeader?.classList.remove("is-dragging");
+      statsDragHandle?.classList.remove("is-dragging");
     }
   });
-});
+}
 
-document.addEventListener("DOMContentLoaded", () => {
+function enhanceInventoryDeleteButtons() {
   document.querySelectorAll(".inventory-delete-btn").forEach((button) => {
     if (button.childElementCount > 0) {
       return;
@@ -11724,99 +11795,133 @@ document.addEventListener("DOMContentLoaded", () => {
     button.appendChild(labelSpan);
     button.classList.add("inventory-delete-btn--overlay");
   });
-});
-
-const settingsButton = document.getElementById("settingsButton");
-const achievementsButton = document.getElementById("achievementsButton");
-const achievementsMenu = document.getElementById("achievementsMenu");
-const closeAchievements = document.getElementById("closeAchievements");
-const statsMenu = document.getElementById("statsMenu");
-const statsButton = document.getElementById("statsButton");
-const closeStats = document.getElementById("closeStats");
-const settingsMenu = document.getElementById("settingsMenu");
-const closeSettings = document.getElementById("closeSettings");
-const audioSlider = document.getElementById("audioSlider");
-const audioSliderValueLabel = document.getElementById("audioSliderValue");
-const resetDataButton = document.getElementById("resetDataButton");
-const autoRollButton = document.getElementById("autoRollButton");
-const rollButton = document.getElementById("rollButton");
-
-settingsButton.addEventListener("click", () => {
-  settingsMenu.style.display = "block";
-});
-
-closeSettings.addEventListener("click", () => {
-  settingsMenu.style.display = "none";
-});
-
-achievementsButton.addEventListener("click", () => {
-  achievementsMenu.style.display = "block";
-  const achievementsBodyElement = achievementsMenu.querySelector(".achievements-body");
-  if (achievementsBodyElement) {
-    achievementsBodyElement.scrollTop = 0;
-  }
-});
-
-closeAchievements.addEventListener("click", () => {
-  achievementsMenu.style.display = "none";
-});
-
-statsButton.addEventListener("click", () => {
-  statsMenu.style.display = "block";
-  statsMenu.style.transform = "translate(-50%, -50%)";
-  statsMenu.style.left = "50%";
-  statsMenu.style.top = "50%";
-});
-
-closeStats.addEventListener("click", () => {
-  statsMenu.style.display = "none";
-});
-
-const muteButton = document.getElementById("muteButton");
-
-const savedVolume = localStorage.getItem("audioVolume");
-if (savedVolume !== null) {
-  audioVolume = parseFloat(savedVolume);
-  previousVolume = audioVolume;
-  audioSlider.value = audioVolume;
-  updateAudioElements(audioVolume);
-} else {
-  updateAudioElements(audioVolume);
 }
-setSliderMutedState(audioVolume === 0);
-updateAudioSliderUi();
 
-audioSlider.addEventListener("input", () => {
-  audioVolume = parseFloat(audioSlider.value);
-  if (audioVolume === 0) {
-    isMuted = true;
-    setSliderMutedState(true);
-  } else {
-    isMuted = false;
-    previousVolume = audioVolume;
-    setSliderMutedState(false);
-  }
-  localStorage.setItem("audioVolume", audioVolume);
-  updateAudioElements(audioVolume);
-  updateAudioSliderUi();
-});
+function registerMenuButtons() {
+  const settingsButton = document.getElementById("settingsButton");
+  const achievementsButton = document.getElementById("achievementsButton");
+  const achievementsMenu = document.getElementById("achievementsMenu");
+  const closeAchievements = document.getElementById("closeAchievements");
+  const statsMenu = document.getElementById("statsMenu");
+  const statsButton = document.getElementById("statsButton");
+  const closeStats = document.getElementById("closeStats");
+  const settingsMenu = document.getElementById("settingsMenu");
+  const closeSettings = document.getElementById("closeSettings");
 
-muteButton.addEventListener("click", () => {
-  isMuted = !isMuted;
-
-  if (isMuted) {
-    previousVolume = audioVolume;
-    audioVolume = 0;
-  } else {
-    audioVolume = previousVolume;
+  if (settingsButton && settingsMenu) {
+    settingsButton.addEventListener("click", () => {
+      settingsMenu.style.display = "flex";
+    });
   }
 
-  audioSlider.value = audioVolume;
-  localStorage.setItem("audioVolume", audioVolume);
+  if (closeSettings && settingsMenu) {
+    closeSettings.addEventListener("click", () => {
+      settingsMenu.style.display = "none";
+    });
+  }
+
+  if (achievementsButton && achievementsMenu) {
+    achievementsButton.addEventListener("click", () => {
+      achievementsMenu.style.display = "flex";
+      const achievementsBodyElement = achievementsMenu.querySelector(".achievements-body");
+      if (achievementsBodyElement) {
+        achievementsBodyElement.scrollTop = 0;
+      }
+    });
+  }
+
+  if (closeAchievements && achievementsMenu) {
+    closeAchievements.addEventListener("click", () => {
+      achievementsMenu.style.display = "none";
+    });
+  }
+
+  if (statsButton && statsMenu) {
+    statsButton.addEventListener("click", () => {
+      statsMenu.style.display = "flex";
+      statsMenu.style.transform = "translate(-50%, -50%)";
+      statsMenu.style.left = "50%";
+      statsMenu.style.top = "50%";
+    });
+  }
+
+  if (closeStats && statsMenu) {
+    closeStats.addEventListener("click", () => {
+      statsMenu.style.display = "none";
+    });
+  }
+}
+
+function setupAudioControls() {
+  audioSliderElement = document.getElementById("audioSlider");
+  audioSliderValueLabelElement = document.getElementById("audioSliderValue");
+  muteButtonElement = document.getElementById("muteButton");
+  const resetDataButton = document.getElementById("resetDataButton");
+
+  const savedVolume = localStorage.getItem("audioVolume");
+  if (savedVolume !== null) {
+    audioVolume = parseFloat(savedVolume);
+    previousVolume = audioVolume;
+  }
+
   updateAudioElements(audioVolume);
-  setSliderMutedState(isMuted);
+
+  if (audioSliderElement) {
+    audioSliderElement.value = audioVolume;
+    audioSliderElement.addEventListener("input", () => {
+      audioVolume = parseFloat(audioSliderElement.value);
+      if (audioVolume === 0) {
+        isMuted = true;
+        setSliderMutedState(true);
+      } else {
+        isMuted = false;
+        previousVolume = audioVolume;
+        setSliderMutedState(false);
+      }
+      localStorage.setItem("audioVolume", audioVolume);
+      updateAudioElements(audioVolume);
+      updateAudioSliderUi();
+    });
+  }
+
+  if (muteButtonElement) {
+    muteButtonElement.addEventListener("click", () => {
+      isMuted = !isMuted;
+
+      if (isMuted) {
+        previousVolume = audioVolume;
+        audioVolume = 0;
+      } else {
+        audioVolume = previousVolume;
+      }
+
+      if (audioSliderElement) {
+        audioSliderElement.value = audioVolume;
+      }
+      localStorage.setItem("audioVolume", audioVolume);
+      updateAudioElements(audioVolume);
+      setSliderMutedState(isMuted);
+      updateAudioSliderUi();
+    });
+  }
+
+  if (resetDataButton) {
+    resetDataButton.addEventListener("click", () => {
+      if (confirm("Are you sure you want to reset all data?")) {
+        console.log("Data reset!");
+        localStorage.clear();
+
+        setTimeout(() => {
+          localStorage.clear();
+          location.reload();
+        }, 100);
+      }
+    });
+  }
+
+  setSliderMutedState(audioVolume === 0);
   updateAudioSliderUi();
-});
+}
 
 function updateAudioElements(volume) {
   const audioElements = document.querySelectorAll("audio");
@@ -11824,22 +11929,22 @@ function updateAudioElements(volume) {
 }
 
 function setSliderMutedState(muted) {
-  if (!audioSlider) {
+  if (!audioSliderElement) {
     return;
   }
 
-  audioSlider.classList.toggle("muted", Boolean(muted));
+  audioSliderElement.classList.toggle("muted", Boolean(muted));
 }
 
 function updateAudioSliderUi() {
-  if (!audioSlider) {
+  if (!audioSliderElement) {
     return;
   }
 
-  const value = Math.max(0, Math.min(1, parseFloat(audioSlider.value) || 0));
+  const value = Math.max(0, Math.min(1, parseFloat(audioSliderElement.value) || 0));
   const percentage = Math.round(value * 100);
-  if (audioSliderValueLabel) {
-    audioSliderValueLabel.textContent = `${percentage}%`;
+  if (audioSliderValueLabelElement) {
+    audioSliderValueLabelElement.textContent = `${percentage}%`;
   }
 
   const startColor = { r: 96, g: 0, b: 126 };
@@ -11849,177 +11954,216 @@ function updateAudioSliderUi() {
   const b = Math.round(startColor.b + (endColor.b - startColor.b) * value);
   const thumbColor = `rgb(${r}, ${g}, ${b})`;
 
-  audioSlider.style.setProperty("--thumb-color", thumbColor);
+  audioSliderElement.style.setProperty("--thumb-color", thumbColor);
 
-  const trackColor = audioSlider.classList.contains("muted")
+  const trackColor = audioSliderElement.classList.contains("muted")
     ? "rgba(128, 96, 186, 0.75)"
     : thumbColor;
 
-  audioSlider.style.background = `linear-gradient(90deg, ${trackColor} ${percentage}%, rgba(255, 255, 255, 0.12) ${percentage}%)`;
+  audioSliderElement.style.background = `linear-gradient(90deg, ${trackColor} ${percentage}%, rgba(255, 255, 255, 0.12) ${percentage}%)`;
 }
 
-resetDataButton.addEventListener("click", () => {
-  if (confirm("Are you sure you want to reset all data?")) {
-    console.log("Data reset!");
-    localStorage.clear();
-    
-    setTimeout(() => {
-      localStorage.clear();
-      location.reload();
-      let playTime = 0;
-    }, 100);
+function initializeAutoRollControls() {
+  autoRollButtonElement = document.getElementById("autoRollButton");
+  if (!autoRollButtonElement) {
+    return;
   }
-});
 
-const savedState = localStorage.getItem("autoRollEnabled");
-if (savedState === "true") {
-  startAutoRoll();
-} else {
-  stopAutoRoll();
-}
-
-autoRollButton.addEventListener("click", () => {
-  if (autoRollInterval) {
-    stopAutoRoll();
-  } else {
+  const savedState = localStorage.getItem("autoRollEnabled");
+  if (savedState === "true") {
     startAutoRoll();
+  } else {
+    stopAutoRoll();
   }
-});
+
+  autoRollButtonElement.addEventListener("click", () => {
+    if (autoRollInterval) {
+      stopAutoRoll();
+    } else {
+      startAutoRoll();
+    }
+  });
+}
 
 function startAutoRoll() {
+  if (!autoRollButtonElement) {
+    return;
+  }
+
   autoRollInterval = setInterval(() => {
-    document.getElementById("rollButton").click();
-  },400);
-  autoRollButton.textContent = "Auto Roll: On";
+    document.getElementById("rollButton")?.click();
+  }, 400);
+  autoRollButtonElement.textContent = "Auto Roll: On";
   console.log("Rolling...");
-  autoRollButton.classList.remove("off");
-  autoRollButton.classList.add("on");
+  autoRollButtonElement.classList.remove("off");
+  autoRollButtonElement.classList.add("on");
   localStorage.setItem("autoRollEnabled", "true");
 }
 
 function stopAutoRoll() {
+  if (!autoRollButtonElement) {
+    return;
+  }
+
   clearInterval(autoRollInterval);
   console.log("Stopped rolling");
   autoRollInterval = null;
-  autoRollButton.textContent = "Auto Roll: Off";
-  autoRollButton.classList.remove("on");
-  autoRollButton.classList.add("off");
+  autoRollButtonElement.textContent = "Auto Roll: Off";
+  autoRollButtonElement.classList.remove("on");
+  autoRollButtonElement.classList.add("off");
   localStorage.setItem("autoRollEnabled", "false");
 }
 
 updateAudioSliderUi();
 
-const heartContainer = document.createElement('div');
-document.body.appendChild(heartContainer);
+function initializeHeartEffect() {
+  if (heartIntervalId) {
+    return;
+  }
 
-function createHeart() {
-    const heart = document.createElement('div');
-    heart.classList.add('heart');
-    heart.textContent = '🌊';
-    heart.style.left = Math.random() * 100 + 'vw';
-    heart.style.top = Math.random() * 100 + 'vh';
-    heart.style.fontSize = Math.random() * 25 + 15 + 'px';
+  if (!heartContainerElement) {
+    heartContainerElement = document.createElement("div");
+    document.body.appendChild(heartContainerElement);
+  }
 
-    heartContainer.appendChild(heart);
+  const createHeart = () => {
+    const heart = document.createElement("div");
+    heart.classList.add("heart");
+    heart.textContent = "🌊";
+    heart.style.left = `${Math.random() * 100}vw`;
+    heart.style.top = `${Math.random() * 100}vh`;
+    heart.style.fontSize = `${Math.random() * 25 + 15}px`;
+
+    heartContainerElement.appendChild(heart);
 
     setTimeout(() => {
-        heart.remove();
+      heart.remove();
     }, 1000);
+  };
+
+  heartIntervalId = setInterval(createHeart, 33);
 }
 
-setInterval(createHeart, 33);
-
-const secretKey = 'ImpeachedGlazer';
-
-document.getElementById('saveButton').addEventListener('click', () => {
-  const data = JSON.stringify(localStorage);
-
-  const encryptedData = CryptoJS.AES.encrypt(data, secretKey).toString();
-
-  const blob = new Blob([encryptedData], { type: 'application/json' });
-  const url = URL.createObjectURL(blob);
-
-  const a = document.createElement('a');
-  a.href = url;
-  a.download = 'localStorageData.json';
-  a.click();
-
-  URL.revokeObjectURL(url);
-});
+const secretKey = "ImpeachedGlazer";
 
 function showStatusMessage(message, duration = 2000) {
-  const status = document.getElementById('status');
+  const status = document.getElementById("status");
+  if (!status) {
+    return;
+  }
+
+  status.style.display = "";
   status.textContent = message;
-  status.classList.add('showStatus');
+  status.classList.add("showStatus");
 
   setTimeout(() => {
-      status.classList.remove('showStatus');
-      setTimeout(() => (status.style.display = 'none'), 500);
+    status.classList.remove("showStatus");
+    setTimeout(() => {
+      if (status.isConnected) {
+        status.style.display = "none";
+      }
+    }, 500);
   }, duration);
 }
 
-    let playTime = parseInt(localStorage.getItem('playTime')) || 0;
-    
-    const timerDisplay = document.getElementById('timer');
+function registerDataPersistenceButtons() {
+  const saveButton = document.getElementById("saveButton");
+  const importButton = document.getElementById("importButton");
 
-    function formatTime(seconds) {
-      const hrs = Math.floor(seconds / 3600);
-      const mins = Math.floor((seconds % 3600) / 60);
-      const secs = seconds % 60;
-      return [
-        hrs.toString().padStart(2, '0'),
-        mins.toString().padStart(2, '0'),
-        secs.toString().padStart(2, '0')
-      ].join(':');
-    }
+  if (saveButton) {
+    saveButton.addEventListener("click", () => {
+      const data = JSON.stringify(localStorage);
+      const encryptedData = CryptoJS.AES.encrypt(data, secretKey).toString();
+      const blob = new Blob([encryptedData], { type: "application/json" });
+      const url = URL.createObjectURL(blob);
 
+      const a = document.createElement("a");
+      a.href = url;
+      a.download = "localStorageData.json";
+      a.click();
+
+      URL.revokeObjectURL(url);
+    });
+  }
+
+  if (importButton) {
+    importButton.addEventListener("click", () => {
+      const input = document.createElement("input");
+      input.type = "file";
+      input.accept = ".json";
+
+      input.addEventListener("change", (event) => {
+        const file = event.target.files?.[0];
+        if (!file) {
+          return;
+        }
+
+        const reader = new FileReader();
+        reader.onload = (e) => {
+          try {
+            const encryptedData = e.target?.result;
+            if (typeof encryptedData !== "string") {
+              throw new Error("Invalid file contents");
+            }
+
+            const bytes = CryptoJS.AES.decrypt(encryptedData, secretKey);
+            const decryptedData = bytes.toString(CryptoJS.enc.Utf8);
+            const importedData = JSON.parse(decryptedData);
+
+            Object.keys(importedData).forEach((key) => {
+              localStorage.setItem(key, importedData[key]);
+            });
+
+            showStatusMessage("Data imported successfully! Refreshing...", 1500);
+
+            setTimeout(() => {
+              location.reload();
+            }, 1500);
+          } catch (error) {
+            showStatusMessage("Error: Invalid file format.");
+          }
+        };
+
+        reader.readAsText(file);
+      });
+
+      input.click();
+    });
+  }
+}
+
+function initializePlayTimeTracker() {
+  if (playTimeIntervalId) {
+    return;
+  }
+
+  let playTime = parseInt(localStorage.getItem("playTime"), 10) || 0;
+  const timerDisplay = document.getElementById("timer");
+  if (!timerDisplay) {
+    return;
+  }
+
+  const formatTime = (seconds) => {
+    const hrs = Math.floor(seconds / 3600);
+    const mins = Math.floor((seconds % 3600) / 60);
+    const secs = seconds % 60;
+    return [
+      hrs.toString().padStart(2, "0"),
+      mins.toString().padStart(2, "0"),
+      secs.toString().padStart(2, "0"),
+    ].join(":");
+  };
+
+  timerDisplay.textContent = formatTime(playTime);
+
+  playTimeIntervalId = setInterval(() => {
+    playTime += 1;
     timerDisplay.textContent = formatTime(playTime);
-
-    setInterval(() => {
-      playTime++;
-      timerDisplay.textContent = formatTime(playTime);
-      localStorage.setItem('playTime', playTime);
-      checkAchievements();
-      updateAchievementsList();
-    }, 1000);
-
-document.getElementById('importButton').addEventListener('click', () => {
-  const input = document.createElement('input');
-  input.type = 'file';
-  input.accept = '.json';
-
-  input.addEventListener('change', (event) => {
-    const file = event.target.files[0];
-    if (file) {
-      const reader = new FileReader();
-      reader.onload = (e) => {
-        try {
-          const encryptedData = e.target.result;
-
-          const bytes = CryptoJS.AES.decrypt(encryptedData, secretKey);
-          const decryptedData = bytes.toString(CryptoJS.enc.Utf8);
-
-          const importedData = JSON.parse(decryptedData);
-
-          Object.keys(importedData).forEach(key => {
-            localStorage.setItem(key, importedData[key]);
-          });
-
-                  showStatusMessage("Data imported successfully! Refreshing...", 1500);
-
-                  setTimeout(() => {
-                      location.reload();
-                  }, 1500);
-              } catch (error) {
-                  showStatusMessage("Error: Invalid file format.");
-              }
-          };
-          reader.readAsText(file);
-      }
-  });
-
-  input.click();
-});
+    localStorage.setItem("playTime", playTime);
+    checkAchievements();
+    updateAchievementsList();
+  }, 1000);
+}
 
 const rollingHistory = [];
 
@@ -12049,12 +12193,23 @@ function updateRollingHistory(title, rarity) {
     });
 }
 
-document.getElementById("deleteAllUnder100Button")?.addEventListener("click", () => deleteByRarityBucket('under100'));
-document.getElementById("deleteAllUnder1kButton")?.addEventListener("click", () => deleteByRarityBucket('under1k'));
-document.getElementById("deleteAllUnder10kButton")?.addEventListener("click", () => deleteByRarityBucket('under10k'));
-document.getElementById("deleteAllUnder100kButton")?.addEventListener("click", () => deleteByRarityBucket('under100k'));
-document.getElementById("deleteAllUnder1mButton")?.addEventListener("click", () => deleteByRarityBucket('under1m'));
-document.getElementById("deleteAllSpecialButton")?.addEventListener("click", () => deleteByRarityBucket('special'));
+function registerRarityDeletionButtons() {
+  const buttonMappings = [
+    ["deleteAllUnder100Button", "under100"],
+    ["deleteAllUnder1kButton", "under1k"],
+    ["deleteAllUnder10kButton", "under10k"],
+    ["deleteAllUnder100kButton", "under100k"],
+    ["deleteAllUnder1mButton", "under1m"],
+    ["deleteAllSpecialButton", "special"],
+  ];
+
+  buttonMappings.forEach(([id, bucket]) => {
+    const button = document.getElementById(id);
+    if (button) {
+      button.addEventListener("click", () => deleteByRarityBucket(bucket));
+    }
+  });
+}
 
 function getClassForRarity(rarity) {
   const rarityClasses = {

--- a/files/style.css
+++ b/files/style.css
@@ -1227,10 +1227,15 @@ body {
     gap: 16px;
     padding: 18px 22px 14px 22px;
     border-bottom: 1px solid rgba(120, 164, 255, 0.16);
-    background: rgba(10, 14, 26, 0.65);
+    background: rgba(10, 14, 26, 0.75);
     backdrop-filter: blur(12px);
     cursor: grab;
     user-select: none;
+    position: sticky;
+    top: 0;
+    z-index: 50;
+    flex: 0 0 auto;
+    box-shadow: 0 6px 14px rgba(4, 8, 16, 0.55);
 }
 
 .settings-header .dragTxt {
@@ -4510,10 +4515,15 @@ body.griCutsceneBgImg {
     gap: 16px;
     padding: 18px 22px 14px 22px;
     border-bottom: 1px solid rgba(120, 164, 255, 0.16);
-    background: rgba(10, 14, 26, 0.65);
+    background: rgba(10, 14, 26, 0.75);
     backdrop-filter: blur(12px);
     cursor: grab;
     user-select: none;
+    position: sticky;
+    top: 0;
+    z-index: 50;
+    flex: 0 0 auto;
+    box-shadow: 0 6px 14px rgba(4, 8, 16, 0.55);
 }
 
 .achievements-header .dragTxt {

--- a/index.html
+++ b/index.html
@@ -476,116 +476,116 @@
         <button class="fullscreen-btn" onclick="toggleFullscreen()"><i class="fa-solid fa-expand"></i></button>
     </div>
 
-    <audio id="click" src="files/sounds_and_music/click.mp3"></audio>
-    <audio id="suspenseAudio" src="files/sounds_and_music/suspence.mp3"></audio>
-    <audio id="geezerSuspenceAudio" src="files/sounds_and_music/geezer_suspence.mp3"></audio>
-    <audio id="polarrSuspenceAudio" src="files/sounds_and_music/polarr_suspence.mp3"></audio>
-    <audio id="scareSuspenceAudio" src="files/sounds_and_music/scare_suspence.mp3"></audio>
-    <audio id="scareSuspenceLofiAudio" src="files/sounds_and_music/scare_suspence_lofi.mp3"></audio>
-    <audio id="bigSuspenceAudio" src="files/sounds_and_music/big_suspence.mp3"></audio>
-    <audio id="hugeSuspenceAudio" src="files/sounds_and_music/onemillionsuspence.mp3"></audio>
-    <audio id="expOpeningAudio" src="files/sounds_and_music/exp_opening.mp3"></audio>
-    <audio id="plabreAudio" src="files/sounds_and_music/plabre.mp3" loop></audio>
-    <audio id="isekailofiAudio" src="files/sounds_and_music/isekailofi.mp3" loop></audio>
-    <audio id="x1staAudio" src="files/sounds_and_music/x1sta.mp3" loop></audio>
-    <audio id="heartAudio" src="files/sounds_and_music/heart.mp3" loop></audio>
-    <audio id="aboAudio" src="files/sounds_and_music/abo.mp3" loop></audio>
-    <audio id="equinoxAudio" src="files/sounds_and_music/equinox.mp3" loop></audio>
-    <audio id="tuonAudio" src="files/sounds_and_music/tuon.mp3" loop></audio>
-    <audio id="msfuAudio" src="files/sounds_and_music/msfu.mp3" loop></audio>
-    <audio id="blindAudio" src="files/sounds_and_music/blind.mp3" loop></audio>
-    <audio id="isekaiAudio" src="files/sounds_and_music/isekai.mp3" loop></audio>
-    <audio id="emerAudio" src="files/sounds_and_music/emergencies.mp3" loop></audio>
-    <audio id="samuraiAudio" src="files/sounds_and_music/samurai.mp3" loop></audio>
-    <audio id="contAudio" src="files/sounds_and_music/contortions.mp3" loop></audio>
-    <audio id="unstoppableAudio" src="files/sounds_and_music/unstoppable.mp3" loop></audio>
-    <audio id="gargantuaAudio" src="files/sounds_and_music/gargantua.mp3" loop></audio>
-    <audio id="spectralAudio" src="files/sounds_and_music/spectral.mp3" loop></audio>
-    <audio id="starfallAudio" src="files/sounds_and_music/starfall.mp3" loop></audio>
-    <audio id="memAudio" src="files/sounds_and_music/memory.mp3" loop></audio>
-    <audio id="oblAudio" src="files/sounds_and_music/oblivion.mp3" loop></audio>
-    <audio id="lubjubAudio" src="files/sounds_and_music/lubjub.mp3" loop></audio>
-    <audio id="shaAudio" src="files/sounds_and_music/sha.mp3" loop></audio>
-    <audio id="phaAudio" src="files/sounds_and_music/phantomstride.mp3" loop></audio>
-    <audio id="frightAudio" src="files/sounds_and_music/fright.mp3" loop></audio>
-    <audio id="unnamedAudio" src="files/sounds_and_music/unnamed.mp3" loop></audio>
-    <audio id="serAudio" src="files/sounds_and_music/seraphwing.mp3" loop></audio>
-    <audio id="arcAudio" src="files/sounds_and_music/arcanepulse.mp3" loop></audio>
-    <audio id="hellAudio" src="files/sounds_and_music/hell.mp3" loop></audio>
-    <audio id="wanspiAudio" src="files/sounds_and_music/wanspi.mp3" loop></audio>
-    <audio id="mysAudio" src="files/sounds_and_music/mys.mp3" loop></audio>
-    <audio id="waveAudio" src="files/sounds_and_music/wave.mp3" loop></audio>
-    <audio id="scorchingAudio" src="files/sounds_and_music/scho.mp3" loop></audio>
-    <audio id="beachAudio" src="files/sounds_and_music/beach.mp3" loop></audio>
-    <audio id="tidalwaveAudio" src="files/sounds_and_music/tidwav.mp3" loop></audio>
-    <audio id="nighAudio" src="files/sounds_and_music/nigh.mp3" loop></audio>
-    <audio id="voiAudio" src="files/sounds_and_music/voi.mp3" loop></audio>
-    <audio id="endAudio" src="files/sounds_and_music/end.mp3" loop></audio>
-    <audio id="shadAudio" src="files/sounds_and_music/shad.mp3" loop></audio>
-    <audio id="froAudio" src="files/sounds_and_music/fro.mp3" loop></audio>
-    <audio id="forgAudio" src="files/sounds_and_music/forg.mp3" loop></audio>
-    <audio id="curartAudio" src="files/sounds_and_music/curart.mp3" loop></audio>
-    <audio id="ghoAudio" src="files/sounds_and_music/gho.mp3" loop></audio>
-    <audio id="abysAudio" src="files/sounds_and_music/abys.mp3" loop></audio>
-    <audio id="twiligAudio" src="files/sounds_and_music/twilig.ogg" loop></audio>
-    <audio id="silAudio" src="files/sounds_and_music/sil.mp3" loop></audio>
-    <audio id="orbAudio" src="files/sounds_and_music/orb.mp3" loop></audio>
-    <audio id="specAudio" src="files/sounds_and_music/spec.mp3" loop></audio>
-    <audio id="ethpulAudio" src="files/sounds_and_music/ethpul.mp3" loop></audio>
-    <audio id="eniAudio" src="files/sounds_and_music/eni.mp3" loop></audio>
-    <audio id="griAudio" src="files/sounds_and_music/gri.mp3" loop></audio>
-    <audio id="celdawAudio" src="files/sounds_and_music/celdaw.mp3" loop></audio>
-    <audio id="fatreAudio" src="files/sounds_and_music/fatre.mp3" loop></audio>
-    <audio id="fearAudio" src="files/sounds_and_music/fear.mp3" loop></audio>
-    <audio id="darAudio" src="files/sounds_and_music/dar.mp3" loop></audio>
-    <audio id="hauAudio" src="files/sounds_and_music/hau.mp3" loop></audio>
-    <audio id="radAudio" src="files/sounds_and_music/rad.mp3" loop></audio>
-    <audio id="lostsAudio" src="files/sounds_and_music/losts.mp3" loop></audio>
-    <audio id="foundsAudio" src="files/sounds_and_music/founds.mp3" loop></audio>
-    <audio id="hauntAudio" src="files/sounds_and_music/haunt.mp3" loop></audio>
-    <audio id="devilAudio" src="files/sounds_and_music/devil.mp3" loop></audio>
-    <audio id="pumpkinAudio" src="files/sounds_and_music/pumpkin.mp3" loop></audio>
-    <audio id="overtureAudio" src="files/sounds_and_music/overture.ogg" loop></audio>
-    <audio id="impeachedAudio" src="files/sounds_and_music/impeached.ogg" loop></audio>
-    <audio id="rngmasterAudio" src="files/sounds_and_music/rngmaster.mp3" loop></audio>
-    <audio id="crazeAudio" src="files/sounds_and_music/firecraze.mp3" loop></audio>
-    <audio id="iriAudio" src="files/sounds_and_music/iri.mp3" loop></audio>
-    <audio id="demsoAudio" src="files/sounds_and_music/demso.mp3" loop></audio>
-    <audio id="fircraAudio" src="files/sounds_and_music/fircra.mp3" loop></audio>
-    <audio id="curAudio" src="files/sounds_and_music/cursed.ogg" loop></audio>
-    <audio id="eonbreakAudio" src="files/sounds_and_music/eonbreak.mp3" loop></audio>
-    <audio id="celAudio" src="files/sounds_and_music/celestialchorus.mpeg" loop></audio>
-    <audio id="silcarAudio" src="files/sounds_and_music/sillycar.mp3" loop></audio>
-    <audio id="ethAudio" src="files/sounds_and_music/ether.mp3" loop></audio>
-    <audio id="gregAudio" src="files/sounds_and_music/greg.mp3" loop></audio>
-    <audio id="mintllieAudio" src="files/sounds_and_music/mintllie.mp3" loop></audio>
-    <audio id="geezerAudio" src="files/sounds_and_music/geezer.m4a" loop></audio>
-    <audio id="polarrAudio" src="files/sounds_and_music/polarr.mp3" loop></audio>
-    <audio id="oppAudio" src="files/sounds_and_music/oppression.mpeg" loop></audio>
-    <audio id="sanclaAudio" src="files/sounds_and_music/sancla.mp3" loop></audio>
-    <audio id="frogarAudio" src="files/sounds_and_music/frogar.mp3" loop></audio>
-    <audio id="reidasAudio" src="files/sounds_and_music/reidas.mp3" loop></audio>
-    <audio id="cancansymAudio" src="files/sounds_and_music/cancansym.mp3" loop></audio>
-    <audio id="ginharAudio" src="files/sounds_and_music/ginhar.mp3" loop></audio>
-    <audio id="jolbelAudio" src="files/sounds_and_music/jolbel.mp3" loop></audio>
-    <audio id="norstaAudio" src="files/sounds_and_music/norsta.mp3" loop></audio>
-    <audio id="silnigAudio" src="files/sounds_and_music/silnig.mp3" loop></audio>
-    <audio id="harvAudio" src="files/sounds_and_music/harv.mp3" loop></audio>
-    <audio id="expAudio" src="files/sounds_and_music/exp.mp3" loop></audio>
-    <audio id="veilAudio" src="files/sounds_and_music/veil.mp3" loop></audio>
-    <audio id="h1diAudio" src="files/sounds_and_music/h1di.mp3" loop></audio>
-    <audio id="blodAudio" src="files/sounds_and_music/blod.mp3" loop></audio>
-    <audio id="shenviiAudio" src="files/sounds_and_music/shenvii.mp3" loop></audio>
-    <audio id="astblaAudio" src="files/sounds_and_music/astbla.mp3" loop></audio>
-    <audio id="astredAudio" src="files/sounds_and_music/astred.mp3" loop></audio>
-    <audio id="qbearAudio" src="files/sounds_and_music/qbear.mp3" loop></audio>
-    <audio id="lightAudio" src="files/sounds_and_music/light.mp3" loop></audio>
-    <audio id="gingerAudio" src="files/sounds_and_music/ginger.mp3" loop></audio>
-    <audio id="esteggAudio" src="files/sounds_and_music/estegg.mp3" loop></audio>
-    <audio id="estbunAudio" src="files/sounds_and_music/estbun.mp3" loop></audio>
-    <!-- <audio id="mainAudio" src="files/sounds_and_music/main.mp3" loop></audio> -->
-    <!-- <audio id="mainAudio" src="files/sounds_and_music/mainEvent.mp3" loop></audio> -->
-    <audio id="mainAudio" src="files/sounds_and_music/mainEvent2.mp3" loop></audio>
+    <audio preload="none" id="click" src="files/sounds_and_music/click.mp3"></audio>
+    <audio preload="none" id="suspenseAudio" src="files/sounds_and_music/suspence.mp3"></audio>
+    <audio preload="none" id="geezerSuspenceAudio" src="files/sounds_and_music/geezer_suspence.mp3"></audio>
+    <audio preload="none" id="polarrSuspenceAudio" src="files/sounds_and_music/polarr_suspence.mp3"></audio>
+    <audio preload="none" id="scareSuspenceAudio" src="files/sounds_and_music/scare_suspence.mp3"></audio>
+    <audio preload="none" id="scareSuspenceLofiAudio" src="files/sounds_and_music/scare_suspence_lofi.mp3"></audio>
+    <audio preload="none" id="bigSuspenceAudio" src="files/sounds_and_music/big_suspence.mp3"></audio>
+    <audio preload="none" id="hugeSuspenceAudio" src="files/sounds_and_music/onemillionsuspence.mp3"></audio>
+    <audio preload="none" id="expOpeningAudio" src="files/sounds_and_music/exp_opening.mp3"></audio>
+    <audio preload="none" id="plabreAudio" src="files/sounds_and_music/plabre.mp3" loop></audio>
+    <audio preload="none" id="isekailofiAudio" src="files/sounds_and_music/isekailofi.mp3" loop></audio>
+    <audio preload="none" id="x1staAudio" src="files/sounds_and_music/x1sta.mp3" loop></audio>
+    <audio preload="none" id="heartAudio" src="files/sounds_and_music/heart.mp3" loop></audio>
+    <audio preload="none" id="aboAudio" src="files/sounds_and_music/abo.mp3" loop></audio>
+    <audio preload="none" id="equinoxAudio" src="files/sounds_and_music/equinox.mp3" loop></audio>
+    <audio preload="none" id="tuonAudio" src="files/sounds_and_music/tuon.mp3" loop></audio>
+    <audio preload="none" id="msfuAudio" src="files/sounds_and_music/msfu.mp3" loop></audio>
+    <audio preload="none" id="blindAudio" src="files/sounds_and_music/blind.mp3" loop></audio>
+    <audio preload="none" id="isekaiAudio" src="files/sounds_and_music/isekai.mp3" loop></audio>
+    <audio preload="none" id="emerAudio" src="files/sounds_and_music/emergencies.mp3" loop></audio>
+    <audio preload="none" id="samuraiAudio" src="files/sounds_and_music/samurai.mp3" loop></audio>
+    <audio preload="none" id="contAudio" src="files/sounds_and_music/contortions.mp3" loop></audio>
+    <audio preload="none" id="unstoppableAudio" src="files/sounds_and_music/unstoppable.mp3" loop></audio>
+    <audio preload="none" id="gargantuaAudio" src="files/sounds_and_music/gargantua.mp3" loop></audio>
+    <audio preload="none" id="spectralAudio" src="files/sounds_and_music/spectral.mp3" loop></audio>
+    <audio preload="none" id="starfallAudio" src="files/sounds_and_music/starfall.mp3" loop></audio>
+    <audio preload="none" id="memAudio" src="files/sounds_and_music/memory.mp3" loop></audio>
+    <audio preload="none" id="oblAudio" src="files/sounds_and_music/oblivion.mp3" loop></audio>
+    <audio preload="none" id="lubjubAudio" src="files/sounds_and_music/lubjub.mp3" loop></audio>
+    <audio preload="none" id="shaAudio" src="files/sounds_and_music/sha.mp3" loop></audio>
+    <audio preload="none" id="phaAudio" src="files/sounds_and_music/phantomstride.mp3" loop></audio>
+    <audio preload="none" id="frightAudio" src="files/sounds_and_music/fright.mp3" loop></audio>
+    <audio preload="none" id="unnamedAudio" src="files/sounds_and_music/unnamed.mp3" loop></audio>
+    <audio preload="none" id="serAudio" src="files/sounds_and_music/seraphwing.mp3" loop></audio>
+    <audio preload="none" id="arcAudio" src="files/sounds_and_music/arcanepulse.mp3" loop></audio>
+    <audio preload="none" id="hellAudio" src="files/sounds_and_music/hell.mp3" loop></audio>
+    <audio preload="none" id="wanspiAudio" src="files/sounds_and_music/wanspi.mp3" loop></audio>
+    <audio preload="none" id="mysAudio" src="files/sounds_and_music/mys.mp3" loop></audio>
+    <audio preload="none" id="waveAudio" src="files/sounds_and_music/wave.mp3" loop></audio>
+    <audio preload="none" id="scorchingAudio" src="files/sounds_and_music/scho.mp3" loop></audio>
+    <audio preload="none" id="beachAudio" src="files/sounds_and_music/beach.mp3" loop></audio>
+    <audio preload="none" id="tidalwaveAudio" src="files/sounds_and_music/tidwav.mp3" loop></audio>
+    <audio preload="none" id="nighAudio" src="files/sounds_and_music/nigh.mp3" loop></audio>
+    <audio preload="none" id="voiAudio" src="files/sounds_and_music/voi.mp3" loop></audio>
+    <audio preload="none" id="endAudio" src="files/sounds_and_music/end.mp3" loop></audio>
+    <audio preload="none" id="shadAudio" src="files/sounds_and_music/shad.mp3" loop></audio>
+    <audio preload="none" id="froAudio" src="files/sounds_and_music/fro.mp3" loop></audio>
+    <audio preload="none" id="forgAudio" src="files/sounds_and_music/forg.mp3" loop></audio>
+    <audio preload="none" id="curartAudio" src="files/sounds_and_music/curart.mp3" loop></audio>
+    <audio preload="none" id="ghoAudio" src="files/sounds_and_music/gho.mp3" loop></audio>
+    <audio preload="none" id="abysAudio" src="files/sounds_and_music/abys.mp3" loop></audio>
+    <audio preload="none" id="twiligAudio" src="files/sounds_and_music/twilig.ogg" loop></audio>
+    <audio preload="none" id="silAudio" src="files/sounds_and_music/sil.mp3" loop></audio>
+    <audio preload="none" id="orbAudio" src="files/sounds_and_music/orb.mp3" loop></audio>
+    <audio preload="none" id="specAudio" src="files/sounds_and_music/spec.mp3" loop></audio>
+    <audio preload="none" id="ethpulAudio" src="files/sounds_and_music/ethpul.mp3" loop></audio>
+    <audio preload="none" id="eniAudio" src="files/sounds_and_music/eni.mp3" loop></audio>
+    <audio preload="none" id="griAudio" src="files/sounds_and_music/gri.mp3" loop></audio>
+    <audio preload="none" id="celdawAudio" src="files/sounds_and_music/celdaw.mp3" loop></audio>
+    <audio preload="none" id="fatreAudio" src="files/sounds_and_music/fatre.mp3" loop></audio>
+    <audio preload="none" id="fearAudio" src="files/sounds_and_music/fear.mp3" loop></audio>
+    <audio preload="none" id="darAudio" src="files/sounds_and_music/dar.mp3" loop></audio>
+    <audio preload="none" id="hauAudio" src="files/sounds_and_music/hau.mp3" loop></audio>
+    <audio preload="none" id="radAudio" src="files/sounds_and_music/rad.mp3" loop></audio>
+    <audio preload="none" id="lostsAudio" src="files/sounds_and_music/losts.mp3" loop></audio>
+    <audio preload="none" id="foundsAudio" src="files/sounds_and_music/founds.mp3" loop></audio>
+    <audio preload="none" id="hauntAudio" src="files/sounds_and_music/haunt.mp3" loop></audio>
+    <audio preload="none" id="devilAudio" src="files/sounds_and_music/devil.mp3" loop></audio>
+    <audio preload="none" id="pumpkinAudio" src="files/sounds_and_music/pumpkin.mp3" loop></audio>
+    <audio preload="none" id="overtureAudio" src="files/sounds_and_music/overture.ogg" loop></audio>
+    <audio preload="none" id="impeachedAudio" src="files/sounds_and_music/impeached.ogg" loop></audio>
+    <audio preload="none" id="rngmasterAudio" src="files/sounds_and_music/rngmaster.mp3" loop></audio>
+    <audio preload="none" id="crazeAudio" src="files/sounds_and_music/firecraze.mp3" loop></audio>
+    <audio preload="none" id="iriAudio" src="files/sounds_and_music/iri.mp3" loop></audio>
+    <audio preload="none" id="demsoAudio" src="files/sounds_and_music/demso.mp3" loop></audio>
+    <audio preload="none" id="fircraAudio" src="files/sounds_and_music/fircra.mp3" loop></audio>
+    <audio preload="none" id="curAudio" src="files/sounds_and_music/cursed.ogg" loop></audio>
+    <audio preload="none" id="eonbreakAudio" src="files/sounds_and_music/eonbreak.mp3" loop></audio>
+    <audio preload="none" id="celAudio" src="files/sounds_and_music/celestialchorus.mpeg" loop></audio>
+    <audio preload="none" id="silcarAudio" src="files/sounds_and_music/sillycar.mp3" loop></audio>
+    <audio preload="none" id="ethAudio" src="files/sounds_and_music/ether.mp3" loop></audio>
+    <audio preload="none" id="gregAudio" src="files/sounds_and_music/greg.mp3" loop></audio>
+    <audio preload="none" id="mintllieAudio" src="files/sounds_and_music/mintllie.mp3" loop></audio>
+    <audio preload="none" id="geezerAudio" src="files/sounds_and_music/geezer.m4a" loop></audio>
+    <audio preload="none" id="polarrAudio" src="files/sounds_and_music/polarr.mp3" loop></audio>
+    <audio preload="none" id="oppAudio" src="files/sounds_and_music/oppression.mpeg" loop></audio>
+    <audio preload="none" id="sanclaAudio" src="files/sounds_and_music/sancla.mp3" loop></audio>
+    <audio preload="none" id="frogarAudio" src="files/sounds_and_music/frogar.mp3" loop></audio>
+    <audio preload="none" id="reidasAudio" src="files/sounds_and_music/reidas.mp3" loop></audio>
+    <audio preload="none" id="cancansymAudio" src="files/sounds_and_music/cancansym.mp3" loop></audio>
+    <audio preload="none" id="ginharAudio" src="files/sounds_and_music/ginhar.mp3" loop></audio>
+    <audio preload="none" id="jolbelAudio" src="files/sounds_and_music/jolbel.mp3" loop></audio>
+    <audio preload="none" id="norstaAudio" src="files/sounds_and_music/norsta.mp3" loop></audio>
+    <audio preload="none" id="silnigAudio" src="files/sounds_and_music/silnig.mp3" loop></audio>
+    <audio preload="none" id="harvAudio" src="files/sounds_and_music/harv.mp3" loop></audio>
+    <audio preload="none" id="expAudio" src="files/sounds_and_music/exp.mp3" loop></audio>
+    <audio preload="none" id="veilAudio" src="files/sounds_and_music/veil.mp3" loop></audio>
+    <audio preload="none" id="h1diAudio" src="files/sounds_and_music/h1di.mp3" loop></audio>
+    <audio preload="none" id="blodAudio" src="files/sounds_and_music/blod.mp3" loop></audio>
+    <audio preload="none" id="shenviiAudio" src="files/sounds_and_music/shenvii.mp3" loop></audio>
+    <audio preload="none" id="astblaAudio" src="files/sounds_and_music/astbla.mp3" loop></audio>
+    <audio preload="none" id="astredAudio" src="files/sounds_and_music/astred.mp3" loop></audio>
+    <audio preload="none" id="qbearAudio" src="files/sounds_and_music/qbear.mp3" loop></audio>
+    <audio preload="none" id="lightAudio" src="files/sounds_and_music/light.mp3" loop></audio>
+    <audio preload="none" id="gingerAudio" src="files/sounds_and_music/ginger.mp3" loop></audio>
+    <audio preload="none" id="esteggAudio" src="files/sounds_and_music/estegg.mp3" loop></audio>
+    <audio preload="none" id="estbunAudio" src="files/sounds_and_music/estbun.mp3" loop></audio>
+    <!-- <audio preload="none" id="mainAudio" src="files/sounds_and_music/main.mp3" loop></audio> -->
+    <!-- <audio preload="none" id="mainAudio" src="files/sounds_and_music/mainEvent.mp3" loop></audio> -->
+    <audio preload="none" id="mainAudio" src="files/sounds_and_music/mainEvent2.mp3" loop></audio>
 
     
     <script src="files/script.js"></script>


### PR DESCRIPTION
## Summary
- gate the loading sequence and background music behind the start button so initialization only runs after opting in
- show overlay menus with their flex layout and raise header z-indices so the draggable bars stay pinned on scroll
- add `preload="none"` to audio elements to prevent browsers from fetching music before the game begins

## Testing
- not run (UI change only)

------
https://chatgpt.com/codex/tasks/task_e_68d67bfed31c8321aa24423fd90e6460