### PR TITLE
Expand achievement lineup with new milestones

### DIFF
--- a/files/script.js
+++ b/files/script.js
@@ -530,35 +530,55 @@ const CUTSCENE_STATE_SETTERS = {
 };
 
 const ACHIEVEMENTS = [
+  // Roll milestones
   { name: "I think I like this", count: 100 },
+  { name: "Finding the Groove", count: 250 },
+  { name: "Hooked Already", count: 500 },
   { name: "This is getting serious", count: 1000 },
+  { name: "Can't Stop Now", count: 2500 },
   { name: "I'm the Roll Master", count: 5000 },
+  { name: "Streak Seeker", count: 7500 },
   { name: "It's over 9000!!", count: 10000 },
+  { name: "Roll Revolution", count: 15000 },
   { name: "When will you stop?", count: 25000 },
   { name: "No Unnamed?", count: 30303 },
+  { name: "Calculated Chaos", count: 40000 },
   { name: "Beyond Luck", count: 50000 },
   { name: "Rolling machine", count: 100000 },
   { name: "Your PC must be burning", count: 250000 },
   { name: "Half a million!1!!1", count: 500000 },
+  { name: "Rolling Virtuoso", count: 750000 },
   { name: "One, Two.. ..One Million!", count: 1000000 },
+  { name: "Millionaire Machine", count: 2000000 },
   { name: "No H1di?", count: 10000000 },
   { name: "Are you really doing this?", count: 25000000 },
   { name: "You have no limits...", count: 50000000 },
   { name: "WHAT HAVE YOU DONE", count: 100000000 },
   { name: "AHHHHHHHHHHH", count: 1000000000 },
+  // Playtime goals
   { name: "Just the beginning", timeCount: 0 },
+  { name: "Just Five More Minutes...", timeCount: 1800 },
   { name: "This doesn't add up", timeCount: 3600 },
   { name: "When does it end...", timeCount: 7200 },
+  { name: "Late Night Grinder", timeCount: 21600 },
   { name: "I swear I'm not addicted...", timeCount: 36000 },
   { name: "Grass? What's that?", timeCount: 86400 },
   { name: "Unnamed's RNG biggest fan", timeCount: 172800 },
+  { name: "Weekday Warrior", timeCount: 432000 },
   { name: "RNG is life!", timeCount: 604800 },
   { name: "I. CAN'T. STOP", timeCount: 1209600 },
   { name: "No Lifer", timeCount: 2629800 },
   { name: "Are you okay?", timeCount: 5259600 },
+  { name: "Seasoned Grinder", timeCount: 9460800 },
   { name: "You are a True No Lifer", timeCount: 15778800 },
   { name: "No one's getting this legit", timeCount: 31557600 },
   { name: "Happy Summer!", timeCount: 1 },
+  // Inventory milestones
+  { name: "Tiny Vault", inventoryCount: 10 },
+  { name: "Growing Gallery", inventoryCount: 25 },
+  { name: "Treasure Trove", inventoryCount: 50 },
+  { name: "Vault Legend", inventoryCount: 100 },
+  // Rarity triumphs
   { name: "Grand Entrance", rarityBucket: "under10k" },
   { name: "One of a Kind", rarityBucket: "special" },
   { name: "Mastered the Odds", rarityBucket: "under100k" },
@@ -570,13 +590,14 @@ const COLLECTOR_ACHIEVEMENTS = [
   { name: "Achievement Hoarder", count: 10 },
   { name: "Achievement Addict", count: 20 },
   { name: "Achievement God", count: 33 },
-  { name: "T̶h̶e̶ ̶U̶l̶t̶i̶m̶a̶t̶e̶ ̶C̶o̶l̶l̶e̶c̶t̶o̶r̶", count: 50 },
+  { name: "Ultimate Collector", count: 50 },
 ];
 
 const ACHIEVEMENT_GROUP_STYLES = [
   { selector: ".achievement-item", unlocked: { backgroundColor: "blue" } },
   { selector: ".achievement-itemT", unlocked: { backgroundColor: "#000fff" } },
   { selector: ".achievement-itemC", unlocked: { backgroundColor: "#ff0000" } },
+  { selector: ".achievement-itemInv", unlocked: { backgroundColor: "#2e8b57" } },
   { selector: ".achievement-itemE", unlocked: { backgroundColor: "#fff000", color: "black" } },
   { selector: ".achievement-itemSum", unlocked: { backgroundColor: "#ff00d9ff" } },
   { selector: ".achievement-itemR", unlocked: { backgroundColor: "#0033ffff" } },
@@ -1118,6 +1139,10 @@ function checkAchievements(context = {}) {
     }
 
     if (achievement.timeCount !== undefined && typeof playTime !== "undefined" && playTime >= achievement.timeCount) {
+      unlockAchievement(achievement.name, unlocked);
+    }
+
+    if (achievement.inventoryCount !== undefined && Array.isArray(inventory) && inventory.length >= achievement.inventoryCount) {
       unlockAchievement(achievement.name, unlocked);
     }
 
@@ -10777,6 +10802,7 @@ function renderInventory() {
   });
 
   updatePagination();
+  checkAchievements();
 }
 
 function toggleLock(itemTitle, listItem, lockButton) {

--- a/files/style.css
+++ b/files/style.css
@@ -4369,6 +4369,7 @@ body.griCutsceneBgImg {
 .achievement-item,
 .achievement-itemT,
 .achievement-itemC,
+.achievement-itemInv,
 .achievement-itemE,
 .achievement-itemSum,
 .achievement-itemR {
@@ -4398,6 +4399,7 @@ body.griCutsceneBgImg {
 
 .achievement-itemT,
 .achievement-itemC,
+.achievement-itemInv,
 .achievement-itemE,
 .achievement-itemSum,
 .achievement-itemR {
@@ -4409,6 +4411,7 @@ body.griCutsceneBgImg {
 .achievement-item:hover,
 .achievement-itemT:hover,
 .achievement-itemC:hover,
+.achievement-itemInv:hover,
 .achievement-itemE:hover,
 .achievement-itemSum:hover,
 .achievement-itemR:hover {
@@ -4429,6 +4432,10 @@ body.griCutsceneBgImg {
     content: "Collect " attr(data-achievement) " achievements to unlock this achievement";
 }
 
+.achievement-itemInv:hover::after {
+    content: "Store " attr(data-items) " items to unlock this achievement";
+}
+
 .achievement-itemE:hover::after,
 .achievement-itemSum:hover::after,
 .achievement-itemR:hover::after {
@@ -4442,6 +4449,7 @@ body.griCutsceneBgImg {
 .achievement-item:hover::after,
 .achievement-itemT:hover::after,
 .achievement-itemC:hover::after,
+.achievement-itemInv:hover::after,
 .achievement-itemE:hover::after,
 .achievement-itemSum:hover::after,
 .achievement-itemR:hover::after {
@@ -4465,6 +4473,7 @@ body.griCutsceneBgImg {
 .achievement-item:hover::before,
 .achievement-itemT:hover::before,
 .achievement-itemC:hover::before,
+.achievement-itemInv:hover::before,
 .achievement-itemE:hover::before,
 .achievement-itemSum:hover::before,
 .achievement-itemR:hover::before {

--- a/index.html
+++ b/index.html
@@ -131,16 +131,24 @@
                     <h4 class="achievements-section__title">Roll Milestones</h4>
                     <div class="achievement-grid">
                         <div class="achievement-item" data-roll="100" data-name="I think I like this">I think I like this</div>
+                        <div class="achievement-item" data-roll="250" data-name="Finding the Groove">Finding the Groove</div>
+                        <div class="achievement-item" data-roll="500" data-name="Hooked Already">Hooked Already</div>
                         <div class="achievement-item" data-roll="1,000" data-name="This is getting serious">This is getting serious</div>
+                        <div class="achievement-item" data-roll="2,500" data-name="Can't Stop Now">Can't Stop Now</div>
                         <div class="achievement-item" data-roll="5,000" data-name="I'm the Roll Master">I'm the Roll Master</div>
+                        <div class="achievement-item" data-roll="7,500" data-name="Streak Seeker">Streak Seeker</div>
                         <div class="achievement-item" data-roll="10,000" data-name="It's over 9000!!">It's over 9000!!</div>
+                        <div class="achievement-item" data-roll="15,000" data-name="Roll Revolution">Roll Revolution</div>
                         <div class="achievement-item" data-roll="25,000" data-name="When will you stop?">When will you stop?</div>
                         <div class="achievement-item" data-roll="30,303" data-name="No Unnamed?">No Unnamed?</div>
+                        <div class="achievement-item" data-roll="40,000" data-name="Calculated Chaos">Calculated Chaos</div>
                         <div class="achievement-item" data-roll="50,000" data-name="Beyond Luck">Beyond Luck</div>
                         <div class="achievement-item" data-roll="100,000" data-name="Rolling machine">Rolling machine</div>
                         <div class="achievement-item" data-roll="250,000" data-name="Your PC must be burning">Your PC must be burning</div>
                         <div class="achievement-item" data-roll="500,000" data-name="Half a million!1!!1">Half a million!1!!1</div>
+                        <div class="achievement-item" data-roll="750,000" data-name="Rolling Virtuoso">Rolling Virtuoso</div>
                         <div class="achievement-item" data-roll="1,000,000" data-name="One, Two.. ..One Million!">One, Two.. ..One Million!</div>
+                        <div class="achievement-item" data-roll="2,000,000" data-name="Millionaire Machine">Millionaire Machine</div>
                         <div class="achievement-item" data-roll="10,000,000" data-name="No H1di?">No H1di?</div>
                         <div class="achievement-item" data-roll="25,000,000" data-name="Are you really doing this?">Are you really doing this?</div>
                         <div class="achievement-item" data-roll="50,000,000" data-name="You have no limits...">You have no limits...</div>
@@ -153,15 +161,19 @@
                     <h4 class="achievements-section__title">Playtime Goals</h4>
                     <div class="achievement-grid">
                         <div class="achievement-itemT" data-time="the game" data-name="Just the beginning">Just the beginning</div>
+                        <div class="achievement-itemT" data-time="thirty minutes" data-name="Just Five More Minutes...">Just Five More Minutes...</div>
                         <div class="achievement-itemT" data-time="one hour" data-name="This doesn't add up">This doesn't add up</div>
                         <div class="achievement-itemT" data-time="two hours" data-name="When does it end...">When does it end...</div>
+                        <div class="achievement-itemT" data-time="six hours" data-name="Late Night Grinder">Late Night Grinder</div>
                         <div class="achievement-itemT" data-time="10 hours" data-name="I swear I'm not addicted...">I swear I'm not addicted...</div>
                         <div class="achievement-itemT" data-time="one day" data-name="Grass? What's that?">Grass? What's that?</div>
                         <div class="achievement-itemT" data-time="two days" data-name="Unnamed's RNG biggest fan">Unnamed's RNG biggest fan</div>
+                        <div class="achievement-itemT" data-time="five days" data-name="Weekday Warrior">Weekday Warrior</div>
                         <div class="achievement-itemT" data-time="one week" data-name="RNG is life!">RNG is life!</div>
                         <div class="achievement-itemT" data-time="two weeks" data-name="I. CAN'T. STOP">I. CAN'T. STOP</div>
                         <div class="achievement-itemT" data-time="a month" data-name="No Lifer">No Lifer</div>
                         <div class="achievement-itemT" data-time="two months" data-name="Are you okay?">Are you okay?</div>
+                        <div class="achievement-itemT" data-time="four months" data-name="Seasoned Grinder">Seasoned Grinder</div>
                         <div class="achievement-itemT" data-time="six months" data-name="You are a True No Lifer">You are a True No Lifer</div>
                         <div class="achievement-itemT" data-time="a year" data-name="No one's getting this legit">No one's getting this legit</div>
                     </div>
@@ -174,7 +186,17 @@
                         <div class="achievement-itemC" data-achievement="10" data-name="Achievement Hoarder">Achievement Hoarder</div>
                         <div class="achievement-itemC" data-achievement="20" data-name="Achievement Addict">Achievement Addict</div>
                         <div class="achievement-itemC" data-achievement="33" data-name="Achievement God">Achievement God</div>
-                        <div class="achievement-itemC" data-achievement="50" data-name="T̶h̶e̶ ̶U̶l̶t̶i̶m̶a̶t̶e̶ ̶C̶o̶l̶l̶e̶c̶t̶o̶r̶">T̶h̶e̶ ̶U̶l̶t̶i̶m̶a̶t̶e̶ ̶C̶o̶l̶l̶e̶c̶t̶o̶r̶<br>(not obtainable)</div>
+                        <div class="achievement-itemC" data-achievement="50" data-name="Ultimate Collector">Ultimate Collector</div>
+                    </div>
+                </section>
+
+                <section class="achievements-section">
+                    <h4 class="achievements-section__title">Vault Mastery</h4>
+                    <div class="achievement-grid">
+                        <div class="achievement-itemInv" data-items="10" data-name="Tiny Vault">Tiny Vault</div>
+                        <div class="achievement-itemInv" data-items="25" data-name="Growing Gallery">Growing Gallery</div>
+                        <div class="achievement-itemInv" data-items="50" data-name="Treasure Trove">Treasure Trove</div>
+                        <div class="achievement-itemInv" data-items="100" data-name="Vault Legend">Vault Legend</div>
                     </div>
                 </section>
 


### PR DESCRIPTION
## Summary
- add new roll and playtime achievements to raise the total unlockable achievements to 55
- introduce inventory-based "Vault Mastery" achievements and refresh collector progress visuals
- style the new achievement tier and ensure unlock tracking reacts to inventory growth

## Testing
- no automated tests were run (not available)

------
https://chatgpt.com/codex/tasks/task_e_68d8ec47b4308321a2ef346818abd365