### PR TITLE
Smooth equinox title flash animation

### DIFF
--- a/files/style.css
+++ b/files/style.css
@@ -4143,11 +4143,12 @@ body.griCutsceneBgImg {
 
 .equinox-flash {
     background: linear-gradient(90deg, #000000 0%, #ffffff 50%, #000000 100%);
-    background-size: 220% 100%;
-    animation: equinox-flash 0.9s steps(2) infinite;
+    background-size: 240% 100%;
+    animation: equinox-flash 0.3s ease-in-out infinite;
     -webkit-background-clip: text;
     background-clip: text;
     color: transparent;
+    opacity: 0.35;
 }
 
 .h1di-flash {
@@ -4225,9 +4226,15 @@ body.griCutsceneBgImg {
 @keyframes equinox-flash {
     0% {
         background-position: 0% 50%;
+        opacity: 0.35;
+    }
+    50% {
+        background-position: 100% 50%;
+        opacity: 1;
     }
     100% {
-        background-position: 100% 50%;
+        background-position: 0% 50%;
+        opacity: 0.35;
     }
 }
 


### PR DESCRIPTION
## Summary
- soften the Equinox title flash to fade in and out on a ~200 BPM beat
- animate the Equinox keyframes with opacity changes for a smoother pulse

## Testing
- Not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68d8ff7fb794832184f19a32e684c87c