### PR TITLE
fix: allow achievement tooltips to overflow

### DIFF
--- a/files/script.js
+++ b/files/script.js
@@ -699,11 +699,23 @@ const ACHIEVEMENTS = [
   { name: "Rolling Virtuoso", count: 750000 },
   { name: "One, Two.. ..One Million!", count: 1000000 },
   { name: "Millionaire Machine", count: 2000000 },
+  { name: "Triple Threat Spinner", count: 3000000 },
+  { name: "Momentum Master", count: 5000000 },
+  { name: "Lucky Tenacity", count: 7500000 },
   { name: "No H1di?", count: 10000000 },
+  { name: "Breaking Reality", count: 15000000 },
   { name: "Are you really doing this?", count: 25000000 },
+  { name: "Multiversal Roller", count: 30000000 },
   { name: "You have no limits...", count: 50000000 },
+  { name: "Anomaly Hunter", count: 75000000 },
   { name: "WHAT HAVE YOU DONE", count: 100000000 },
+  { name: "Oddity Voyager", count: 150000000 },
+  { name: "Improbability Engine", count: 300000000 },
+  { name: "Beyond Imagination", count: 500000000 },
   { name: "AHHHHHHHHHHH", count: 1000000000 },
+  { name: "Worldshaper", count: 2500000000 },
+  { name: "Entropy Rewriter", count: 5000000000 },
+  { name: "RNG Architect", count: 25000000000 },
   // Playtime goals
   { name: "Just the beginning", timeCount: 0 },
   { name: "Just Five More Minutes...", timeCount: 1800 },
@@ -721,7 +733,16 @@ const ACHIEVEMENTS = [
   { name: "Seasoned Grinder", timeCount: 9460800 },
   { name: "You are a True No Lifer", timeCount: 15778800 },
   { name: "No one's getting this legit", timeCount: 31557600 },
-  { name: "Happy Summer!", timeCount: 1 },
+  { name: "Two Years Deep", timeCount: 63115200 },
+  { name: "Triennial Tenacity", timeCount: 94672800 },
+  { name: "Four-Year Fixture", timeCount: 126230400 },
+  { name: "Half-Decade Hero", timeCount: 157788000 },
+  { name: "Seven-Year Streak", timeCount: 220903200 },
+  { name: "Decade of Determination", timeCount: 315576000 },
+  { name: "Fifteen-Year Folly", timeCount: 473364000 },
+  { name: "Twenty-Year Timeline", timeCount: 631152000 },
+  { name: "Quarter-Century Quest", timeCount: 788940000 },
+  { name: "Timeless Wanderer", timeCount: 946728000 },
   // Inventory milestones
   { name: "Tiny Vault", inventoryCount: 10 },
   { name: "Growing Gallery", inventoryCount: 25 },
@@ -732,6 +753,33 @@ const ACHIEVEMENTS = [
   { name: "One of a Kind", rarityBucket: "special" },
   { name: "Mastered the Odds", rarityBucket: "under100k" },
   { name: "Supreme Fortune", rarityBucket: "under1m" },
+  // Title triumphs
+  { name: "Celestial Alignment", requiredTitle: "『Equinox』 [1 in 25,000,000]" },
+  { name: "Creator?!", requiredTitle: "Unnamed [1 in 30,303]" },
+  { name: "Silly Joyride", requiredTitle: "Silly Car :3 [1 in 1,000,000]" },
+  { name: "Ginger Guardian", requiredTitle: "Ginger [1 in 1,144,141]" },
+  { name: "H1di Hunted", requiredTitle: "H1di [1 in 9,890,089]" },
+  { name: "902.. released.. wilderness..", requiredTitle: "Experiment [1 in 100,000/10th]" },
+  { name: "Abomination Wrangler", requiredTitle: "Abomination [1 in 1,000,000/20th]" },
+  { name: "Veiled Visionary", requiredTitle: "Veil [1 in 50,000/5th]" },
+  { name: "Iridocyclitis Survivor", requiredTitle: "Iridocyclitis Veil [1 in 5,000/50th]" },
+  { name: "Cherry Grove Champion", requiredTitle: "LubbyJubby's Cherry Grove [1 in 5,666]" },
+  { name: "Firestarter", requiredTitle: "FireCraze [1 in 4,200/69th]" },
+  { name: "Orbital Dreamer", requiredTitle: "ORB [1 in 55,555/30th]" },
+  { name: "Gregarious Encounter", requiredTitle: "Greg [1 in 50,000,000]" },
+  { name: "Mint Condition", requiredTitle: "Mintllie [1 in 500,000,000]" },
+  { name: "Geezer Whisperer", requiredTitle: "Geezer [1 in 5,000,000,000]" },
+  { name: "Polar Lights", requiredTitle: "Polarr [1 in 50,000,000,000]" },
+  // Event exclusives
+  { name: "Happy Easter!", requiredEventBucket: "eventE" },
+  { name: "Happy Summer!", requiredEventBucket: "eventS" },
+  { name: "Seasonal Tourist", minEventTitleCount: 1 },
+  { name: "Valentine's Sweetheart", requiredEventBucket: "eventV" },
+  { name: "Festival Firecracker", requiredEventBucket: "eventTitle" },
+  { name: "Spooky Spectator", requiredEventBucket: "eventTitleHalloween" },
+  { name: "Winter Wonderland", requiredEventBucket: "eventTitleXmas" },
+  { name: "Event Explorer", minDistinctEventBuckets: 3 },
+  { name: "Seasonal Archivist", minEventTitleCount: 10 },
 ];
 
 const COLLECTOR_ACHIEVEMENTS = [
@@ -750,6 +798,8 @@ const ACHIEVEMENT_GROUP_STYLES = [
   { selector: ".achievement-itemE", unlocked: { backgroundColor: "#fff000", color: "black" } },
   { selector: ".achievement-itemSum", unlocked: { backgroundColor: "#ff00d9ff" } },
   { selector: ".achievement-itemR", unlocked: { backgroundColor: "#0033ffff" } },
+  { selector: ".achievement-itemTitle", unlocked: { backgroundColor: "#7a3cff" } },
+  { selector: ".achievement-itemEvent", unlocked: { backgroundColor: "#ff8800", color: "black" } },
 ];
 
 const ACHIEVEMENT_TOAST_DURATION = 3400;
@@ -1282,6 +1332,32 @@ function checkAchievements(context = {}) {
     ? context.rarityBuckets
     : new Set(storage.get("rolledRarityBuckets", []));
   const qualifyingInventoryCount = getQualifyingInventoryCount();
+  const inventoryTitleSet = new Set();
+  const eventBucketCounts = new Map();
+  let totalEventTitleCount = 0;
+
+  if (Array.isArray(inventory)) {
+    inventory.forEach((item) => {
+      if (!item || typeof item !== "object") {
+        return;
+      }
+
+      if (typeof item.title === "string" && item.title) {
+        inventoryTitleSet.add(item.title);
+      }
+
+      const bucket =
+        (typeof item.rarityBucket === "string" && item.rarityBucket) ||
+        normalizeRarityBucket(item.rarityClass);
+
+      if (bucket && bucket.startsWith("event")) {
+        totalEventTitleCount += 1;
+        eventBucketCounts.set(bucket, (eventBucketCounts.get(bucket) || 0) + 1);
+      }
+    });
+  }
+
+  const distinctEventBucketCount = eventBucketCounts.size;
 
   ACHIEVEMENTS.forEach((achievement) => {
     if (achievement.count && rollCount >= achievement.count) {
@@ -1304,6 +1380,57 @@ function checkAchievements(context = {}) {
     }
 
     if (achievement.rarityBucket && rarityBuckets.has(achievement.rarityBucket)) {
+      unlockAchievement(achievement.name, unlocked);
+    }
+
+    if (
+      achievement.requiredTitle &&
+      inventoryTitleSet.has(achievement.requiredTitle)
+    ) {
+      unlockAchievement(achievement.name, unlocked);
+    }
+
+    if (
+      Array.isArray(achievement.requiredTitles) &&
+      achievement.requiredTitles.every((title) => inventoryTitleSet.has(title))
+    ) {
+      unlockAchievement(achievement.name, unlocked);
+    }
+
+    if (
+      Array.isArray(achievement.anyTitle) &&
+      achievement.anyTitle.some((title) => inventoryTitleSet.has(title))
+    ) {
+      unlockAchievement(achievement.name, unlocked);
+    }
+
+    if (
+      achievement.requiredEventBucket &&
+      eventBucketCounts.has(achievement.requiredEventBucket)
+    ) {
+      unlockAchievement(achievement.name, unlocked);
+    }
+
+    if (
+      Array.isArray(achievement.requiredEventBuckets) &&
+      achievement.requiredEventBuckets.every((bucket) =>
+        eventBucketCounts.has(bucket)
+      )
+    ) {
+      unlockAchievement(achievement.name, unlocked);
+    }
+
+    if (
+      typeof achievement.minDistinctEventBuckets === "number" &&
+      distinctEventBucketCount >= achievement.minDistinctEventBuckets
+    ) {
+      unlockAchievement(achievement.name, unlocked);
+    }
+
+    if (
+      typeof achievement.minEventTitleCount === "number" &&
+      totalEventTitleCount >= achievement.minEventTitleCount
+    ) {
       unlockAchievement(achievement.name, unlocked);
     }
   });

--- a/files/style.css
+++ b/files/style.css
@@ -4440,7 +4440,9 @@ body.griCutsceneBgImg {
 .achievement-itemInv,
 .achievement-itemE,
 .achievement-itemSum,
-.achievement-itemR {
+.achievement-itemR,
+.achievement-itemTitle,
+.achievement-itemEvent {
     position: relative;
     padding: 16px 14px;
     text-align: center;
@@ -4470,7 +4472,9 @@ body.griCutsceneBgImg {
 .achievement-itemInv,
 .achievement-itemE,
 .achievement-itemSum,
-.achievement-itemR {
+.achievement-itemR,
+.achievement-itemTitle,
+.achievement-itemEvent {
     font-size: 0.9rem;
     padding-left: 12px;
     padding-right: 12px;
@@ -4482,7 +4486,9 @@ body.griCutsceneBgImg {
 .achievement-itemInv:hover,
 .achievement-itemE:hover,
 .achievement-itemSum:hover,
-.achievement-itemR:hover {
+.achievement-itemR:hover,
+.achievement-itemTitle:hover,
+.achievement-itemEvent:hover {
     transform: translateY(-2px);
     background: linear-gradient(155deg, rgba(62, 86, 138, 0.9), rgba(26, 36, 64, 0.95));
     border-color: rgba(167, 205, 255, 0.4);
@@ -4514,13 +4520,23 @@ body.griCutsceneBgImg {
     content: "Get " attr(data-rarity) " rarity to unlock this achievement";
 }
 
+.achievement-itemTitle:hover::after {
+    content: "Obtain " attr(data-title) " to unlock this achievement";
+}
+
+.achievement-itemEvent:hover::after {
+    content: attr(data-event);
+}
+
 .achievement-item:hover::after,
 .achievement-itemT:hover::after,
 .achievement-itemC:hover::after,
 .achievement-itemInv:hover::after,
 .achievement-itemE:hover::after,
 .achievement-itemSum:hover::after,
-.achievement-itemR:hover::after {
+.achievement-itemR:hover::after,
+.achievement-itemTitle:hover::after,
+.achievement-itemEvent:hover::after {
     position: absolute;
     bottom: 100%;
     left: 50%;
@@ -4544,7 +4560,9 @@ body.griCutsceneBgImg {
 .achievement-itemInv:hover::before,
 .achievement-itemE:hover::before,
 .achievement-itemSum:hover::before,
-.achievement-itemR:hover::before {
+.achievement-itemR:hover::before,
+.achievement-itemTitle:hover::before,
+.achievement-itemEvent:hover::before {
     content: "";
     position: absolute;
     bottom: 100%;
@@ -4581,7 +4599,7 @@ body.griCutsceneBgImg {
     flex-direction: column;
     color: #f1f5ff;
     z-index: 10000000;
-    overflow: hidden;
+    overflow: visible;
     scrollbar-width: thin;
     scrollbar-color: #7aa2ff #181a2c;
 }
@@ -4597,7 +4615,7 @@ body.griCutsceneBgImg {
     border-radius: 18px;
     border: 1px solid rgba(120, 164, 255, 0.24);
     box-shadow: 0 24px 60px rgba(0, 0, 0, 0.55);
-    overflow: auto;
+    overflow: visible;
     min-height: 0;
 }
 
@@ -4655,6 +4673,7 @@ body.griCutsceneBgImg {
 .achievements-body {
     flex: 1;
     overflow-y: auto;
+    overflow-x: visible;
     padding: 20px 24px 28px 24px;
     display: flex;
     flex-direction: column;

--- a/index.html
+++ b/index.html
@@ -149,11 +149,23 @@
                         <div class="achievement-item" data-roll="750,000" data-name="Rolling Virtuoso">Rolling Virtuoso</div>
                         <div class="achievement-item" data-roll="1,000,000" data-name="One, Two.. ..One Million!">One, Two.. ..One Million!</div>
                         <div class="achievement-item" data-roll="2,000,000" data-name="Millionaire Machine">Millionaire Machine</div>
+                        <div class="achievement-item" data-roll="3,000,000" data-name="Triple Threat Spinner">Triple Threat Spinner</div>
+                        <div class="achievement-item" data-roll="5,000,000" data-name="Momentum Master">Momentum Master</div>
+                        <div class="achievement-item" data-roll="7,500,000" data-name="Lucky Tenacity">Lucky Tenacity</div>
                         <div class="achievement-item" data-roll="10,000,000" data-name="No H1di?">No H1di?</div>
+                        <div class="achievement-item" data-roll="15,000,000" data-name="Breaking Reality">Breaking Reality</div>
                         <div class="achievement-item" data-roll="25,000,000" data-name="Are you really doing this?">Are you really doing this?</div>
+                        <div class="achievement-item" data-roll="30,000,000" data-name="Multiversal Roller">Multiversal Roller</div>
                         <div class="achievement-item" data-roll="50,000,000" data-name="You have no limits...">You have no limits...</div>
+                        <div class="achievement-item" data-roll="75,000,000" data-name="Anomaly Hunter">Anomaly Hunter</div>
                         <div class="achievement-item" data-roll="100,000,000" data-name="WHAT HAVE YOU DONE">WHAT HAVE YOU DONE</div>
+                        <div class="achievement-item" data-roll="150,000,000" data-name="Oddity Voyager">Oddity Voyager</div>
+                        <div class="achievement-item" data-roll="300,000,000" data-name="Improbability Engine">Improbability Engine</div>
+                        <div class="achievement-item" data-roll="500,000,000" data-name="Beyond Imagination">Beyond Imagination</div>
                         <div class="achievement-item" data-roll="1,000,000,000" data-name="AHHHHHHHHHHH">AHHHHHHHHHHH</div>
+                        <div class="achievement-item" data-roll="2,500,000,000" data-name="Worldshaper">Worldshaper</div>
+                        <div class="achievement-item" data-roll="5,000,000,000" data-name="Entropy Rewriter">Entropy Rewriter</div>
+                        <div class="achievement-item" data-roll="25,000,000,000" data-name="RNG Architect">RNG Architect</div>
                     </div>
                 </section>
 
@@ -176,6 +188,16 @@
                         <div class="achievement-itemT" data-time="four months" data-name="Seasoned Grinder">Seasoned Grinder</div>
                         <div class="achievement-itemT" data-time="six months" data-name="You are a True No Lifer">You are a True No Lifer</div>
                         <div class="achievement-itemT" data-time="a year" data-name="No one's getting this legit">No one's getting this legit</div>
+                        <div class="achievement-itemT" data-time="two years" data-name="Two Years Deep">Two Years Deep</div>
+                        <div class="achievement-itemT" data-time="three years" data-name="Triennial Tenacity">Triennial Tenacity</div>
+                        <div class="achievement-itemT" data-time="four years" data-name="Four-Year Fixture">Four-Year Fixture</div>
+                        <div class="achievement-itemT" data-time="five years" data-name="Half-Decade Hero">Half-Decade Hero</div>
+                        <div class="achievement-itemT" data-time="seven years" data-name="Seven-Year Streak">Seven-Year Streak</div>
+                        <div class="achievement-itemT" data-time="ten years" data-name="Decade of Determination">Decade of Determination</div>
+                        <div class="achievement-itemT" data-time="fifteen years" data-name="Fifteen-Year Folly">Fifteen-Year Folly</div>
+                        <div class="achievement-itemT" data-time="twenty years" data-name="Twenty-Year Timeline">Twenty-Year Timeline</div>
+                        <div class="achievement-itemT" data-time="twenty-five years" data-name="Quarter-Century Quest">Quarter-Century Quest</div>
+                        <div class="achievement-itemT" data-time="thirty years" data-name="Timeless Wanderer">Timeless Wanderer</div>
                     </div>
                 </section>
 
@@ -212,17 +234,71 @@
                 </section>
 
                 <section class="achievements-section">
+                    <h4 class="achievements-section__title">Title Legends</h4>
+                    <div class="achievement-grid">
+                        <div class="achievement-itemTitle" data-title="『Equinox』 [1 in 25,000,000]" data-name="Celestial Alignment">Celestial Alignment</div>
+                        <div class="achievement-itemTitle" data-title="Unnamed [1 in 30,303]" data-name="Creator?!">Creator?!</div>
+                        <div class="achievement-itemTitle" data-title="Silly Car :3 [1 in 1,000,000]" data-name="Silly Joyride">Silly Joyride</div>
+                        <div class="achievement-itemTitle" data-title="Ginger [1 in 1,144,141]" data-name="Ginger Guardian">Ginger Guardian</div>
+                        <div class="achievement-itemTitle" data-title="H1di [1 in 9,890,089]" data-name="H1di Hunted">H1di Hunted</div>
+                        <div class="achievement-itemTitle" data-title="Experiment [1 in 100,000/10th]" data-name="902.. released.. wilderness..">902.. released.. wilderness..</div>
+                        <div class="achievement-itemTitle" data-title="Abomination [1 in 1,000,000/20th]" data-name="Abomination Wrangler">Abomination Wrangler</div>
+                        <div class="achievement-itemTitle" data-title="Veil [1 in 50,000/5th]" data-name="Veiled Visionary">Veiled Visionary</div>
+                        <div class="achievement-itemTitle" data-title="Iridocyclitis Veil [1 in 5,000/50th]" data-name="Iridocyclitis Survivor">Iridocyclitis Survivor</div>
+                        <div class="achievement-itemTitle" data-title="LubbyJubby's Cherry Grove [1 in 5,666]" data-name="Cherry Grove Champion">Cherry Grove Champion</div>
+                        <div class="achievement-itemTitle" data-title="FireCraze [1 in 4,200/69th]" data-name="Firestarter">Firestarter</div>
+                        <div class="achievement-itemTitle" data-title="ORB [1 in 55,555/30th]" data-name="Orbital Dreamer">Orbital Dreamer</div>
+                        <div class="achievement-itemTitle" data-title="Greg [1 in 50,000,000]" data-name="Gregarious Encounter">Gregarious Encounter</div>
+                        <div class="achievement-itemTitle" data-title="Mintllie [1 in 500,000,000]" data-name="Mint Condition">Mint Condition</div>
+                        <div class="achievement-itemTitle" data-title="Geezer [1 in 5,000,000,000]" data-name="Geezer Whisperer">Geezer Whisperer</div>
+                        <div class="achievement-itemTitle" data-title="Polarr [1 in 50,000,000,000]" data-name="Polar Lights">Polar Lights</div>
+                    </div>
+                </section>
+
+                <section class="achievements-section">
                     <h4 class="achievements-section__title">Event Exclusives</h4>
                     <div class="achievements-subsection">
                         <h5 class="achievements-section__subtitle">Spring &amp; Easter</h5>
                         <div class="achievement-grid">
-                            <div class="achievement-itemE" data-time="the Easter Event" data-name="Happy Easter!">Happy Easter!</div>
+                            <div class="achievement-itemE achievement-itemEvent" data-event="Obtain an Easter event title to unlock this achievement" data-name="Happy Easter!">Happy Easter!</div>
                         </div>
                     </div>
                     <div class="achievements-subsection">
                         <h5 class="achievements-section__subtitle">Summer</h5>
                         <div class="achievement-grid">
-                            <div class="achievement-itemSum" data-time="the Summer Event" data-name="Happy Summer!">Happy Summer!</div>
+                            <div class="achievement-itemSum achievement-itemEvent" data-event="Obtain a Summer event title to unlock this achievement" data-name="Happy Summer!">Happy Summer!</div>
+                        </div>
+                    </div>
+                    <div class="achievements-subsection">
+                        <h5 class="achievements-section__subtitle">Valentine's</h5>
+                        <div class="achievement-grid">
+                            <div class="achievement-itemEvent" data-event="Share the love with a Valentine's event title to unlock this achievement" data-name="Valentine's Sweetheart">Valentine's Sweetheart</div>
+                        </div>
+                    </div>
+                    <div class="achievements-subsection">
+                        <h5 class="achievements-section__subtitle">Festival of Fire</h5>
+                        <div class="achievement-grid">
+                            <div class="achievement-itemEvent" data-event="Secure the Firecracker festival title to unlock this achievement" data-name="Festival Firecracker">Festival Firecracker</div>
+                        </div>
+                    </div>
+                    <div class="achievements-subsection">
+                        <h5 class="achievements-section__subtitle">Halloween</h5>
+                        <div class="achievement-grid">
+                            <div class="achievement-itemEvent" data-event="Collect a Halloween-exclusive title to unlock this achievement" data-name="Spooky Spectator">Spooky Spectator</div>
+                        </div>
+                    </div>
+                    <div class="achievements-subsection">
+                        <h5 class="achievements-section__subtitle">Winter Holidays</h5>
+                        <div class="achievement-grid">
+                            <div class="achievement-itemEvent" data-event="Gather a Winter holiday title to unlock this achievement" data-name="Winter Wonderland">Winter Wonderland</div>
+                        </div>
+                    </div>
+                    <div class="achievements-subsection">
+                        <h5 class="achievements-section__subtitle">Seasonal Collections</h5>
+                        <div class="achievement-grid">
+                            <div class="achievement-itemEvent" data-event="Obtain any event title to unlock this achievement" data-name="Seasonal Tourist">Seasonal Tourist</div>
+                            <div class="achievement-itemEvent" data-event="Hold titles from three different events to unlock this achievement" data-name="Event Explorer">Event Explorer</div>
+                            <div class="achievement-itemEvent" data-event="Store 10 event titles across your vault to unlock this achievement" data-name="Seasonal Archivist">Seasonal Archivist</div>
                         </div>
                     </div>
                 </section>


### PR DESCRIPTION
## Summary
- allow the achievement menu containers to expose tooltip content so hover text can extend past the panel without triggering scrollbars

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68d9025a25d483218fbce389dcbf27fb