### PR TITLE
Guard optional heart effect initializer

### DIFF
--- a/files/script.js
+++ b/files/script.js
@@ -550,7 +550,9 @@ function initializeAfterStart() {
   enhanceInventoryDeleteButtons();
   setupAudioControls();
   initializeAutoRollControls();
-  initializeHeartEffect();
+  if (typeof initializeHeartEffect === "function") {
+    initializeHeartEffect();
+  }
   registerDataPersistenceButtons();
   initializePlayTimeTracker();
   registerRarityDeletionButtons();


### PR DESCRIPTION
## Summary
- prevent the optional heart effect initializer from breaking the rest of the start-up sequence when it is not defined
- ensure the playtime tracker initialises so the timer and related achievements update again

## Testing
- Manual verification in a local browser session that the playtime timer increments after starting the game

------
https://chatgpt.com/codex/tasks/task_e_68d946722b1c83218c2459552d8d7b23