### PR TITLE
Reposition roll display and update cutscene failsafe

### DIFF
--- a/files/script.js
+++ b/files/script.js
@@ -82,6 +82,7 @@ let rollDisplayHiddenByUser = false;
 let cutsceneHidRollDisplay = false;
 let cutsceneActive = false;
 let cutsceneFailsafeTimeout = null;
+const CUTSCENE_FAILSAFE_DURATION_MS = 40000;
 let lastRollPersisted = true;
 let lastRollAutoDeleted = false;
 let lastRollRarityClass = null;
@@ -287,7 +288,7 @@ function scheduleCutsceneFailsafe() {
     isChangeEnabled = true;
     finalizeCutsceneState();
     setRollButtonEnabled(true);
-  }, 15000);
+  }, CUTSCENE_FAILSAFE_DURATION_MS);
 }
 
 function finalizeCutsceneState() {
@@ -12854,16 +12855,8 @@ function showCooldownEffect(duration) {
 
   const countdownDisplay = document.createElement("div");
   countdownDisplay.id = "countdownDisplay";
-  countdownDisplay.style.position = "fixed";
-  countdownDisplay.style.bottom = "20px";
-  countdownDisplay.style.right = "20px";
-  countdownDisplay.style.backgroundColor = "rgba(0, 0, 0, 0.7)";
-  countdownDisplay.style.color = "white";
-  countdownDisplay.style.padding = "10px";
-  countdownDisplay.style.borderRadius = "5px";
-  countdownDisplay.style.zIndex = "100000";
-
-  countdownDisplay.innerText = `Roll-Cooldown Effect: ${duration}s`;
+  countdownDisplay.className = "roll-cooldown-display";
+  countdownDisplay.textContent = `Roll-Cooldown Effect: ${duration}s`;
   document.body.appendChild(countdownDisplay);
 
   let timeLeft = duration - 1;
@@ -12876,7 +12869,7 @@ function showCooldownEffect(duration) {
       return;
     }
 
-    countdownDisplay.innerText = `Roll-Cooldown Effect: ${timeLeft}s`;
+    countdownDisplay.textContent = `Roll-Cooldown Effect: ${timeLeft}s`;
     timeLeft--;
   }, 1000);
 }

--- a/files/style.css
+++ b/files/style.css
@@ -619,7 +619,10 @@ body.equinox-pulse-active :is(
         font-size: 16px;
     }
     .container {
-        width: 90%;
+        width: min(92vw, 520px);
+        bottom: 28px;
+        margin-left: 0;
+        transform: translateX(-50%);
     }
     #rollingHistory {
         visibility: hidden;
@@ -631,7 +634,10 @@ body.equinox-pulse-active :is(
         font-size: 14px;
     }
     .container {
-        width: 100%;
+        width: min(94vw, 460px);
+        bottom: 24px;
+        margin-left: 0;
+        transform: translateX(-50%);
     }
     #rollingHistory {
         visibility: hidden;
@@ -639,31 +645,60 @@ body.equinox-pulse-active :is(
     .container1 {
         left: 10px;
     }
+    .version {
+        top: 12px;
+    }
 }
 
 .version {
     color: #fff;
-    position: absolute;
-    bottom: 25px;
-    width: 100%;
-    z-index: 9;
+    position: fixed;
+    top: 20px;
+    left: 50%;
+    transform: translateX(-50%);
+    display: flex;
+    justify-content: center;
+    width: auto;
+    z-index: 100010;
+    pointer-events: none;
 }
 
 .vNumber {
-    font-weight: bold;
-    font-size: large;
-    left: 50%;
-    z-index: 9999999;
-    width: 300px;
-    padding: 20px;
-    background-color: #00000069;
-    border-radius: 25px;
+    display: inline-flex;
+    align-items: baseline;
+    gap: 10px;
+    padding: 10px 18px;
+    font-weight: 600;
+    font-size: 15px;
+    letter-spacing: 0.08em;
+    text-transform: uppercase;
+    color: #f9f9f9;
+    background:
+        linear-gradient(180deg, rgba(40, 40, 40, 0.75), rgba(22, 22, 22, 0.85));
+    border: 1px solid rgba(255, 255, 255, 0.16);
+    border-radius: 999px;
+    box-shadow:
+        0 10px 24px rgba(0, 0, 0, 0.35),
+        inset 0 1px 0 rgba(255, 255, 255, 0.18);
+    backdrop-filter: blur(8px);
+}
+
+.vNumberLabel {
+    font-size: 12px;
+    color: rgba(255, 255, 255, 0.7);
+    letter-spacing: 0.14em;
+}
+
+.vNumberValue {
+    font-size: 18px;
+    font-weight: 700;
+    color: #ffffff;
 }
 
 .vNumberDetailed {
-    color: #999;
-    display: inline;
-    margin-left: 5px;
+    color: rgba(180, 200, 255, 0.8);
+    font-size: 14px;
+    letter-spacing: 0.05em;
 }
 
 .heart {
@@ -838,11 +873,15 @@ body {
 
 /* Replace the old .container block with this */
 .container {
-  position: relative;
-  margin: 25vh auto 0 auto;          /* keep your vertical offset, center horizontally */
+  position: fixed;
+  left: 50%;
+  bottom: 36px;
+  transform: translateX(-50%);
+  margin: 0;
+  margin-left: 180px;
   display: inline-block;
   padding: 18px 18px 22px;
-  width: min(92vw, 740px);
+  width: min(80vw, 560px);
   border-radius: 16px;
 
   /* Layered glass look with your background image subtly present */
@@ -863,7 +902,7 @@ body {
 
   overflow: hidden;
   isolation: isolate;                 /* ensures pseudo-elements stack within */
-  z-index: 9999;                      /* same z-index as your old */
+  z-index: 100000;                    /* keep above surrounding UI */
 }
 
 /* Subtle animated sheen across the panel */
@@ -4151,14 +4190,47 @@ body.flashing {
     transform: scale(1.05);
 }
 
-#countdownDisplay {
-    background-color: rgba(0, 0, 0, 0.7);
-    color: white;
-    padding: 10px;
-    border-radius: 5px;
-    font-size: 14px;
-    z-index: 1000;
-    box-shadow: 0 2px 10px rgba(0, 0, 0, 0.5);
+#countdownDisplay,
+.roll-cooldown-display {
+    position: fixed;
+    right: 32px;
+    bottom: 32px;
+    display: inline-flex;
+    align-items: center;
+    gap: 10px;
+    padding: 12px 18px;
+    color: #f3f6ff;
+    font-size: 15px;
+    font-weight: 600;
+    letter-spacing: 0.05em;
+    background:
+        linear-gradient(180deg, rgba(26, 30, 40, 0.78), rgba(16, 18, 24, 0.88));
+    border: 1px solid rgba(118, 169, 255, 0.35);
+    border-radius: 14px;
+    box-shadow:
+        0 14px 30px rgba(0, 0, 0, 0.45),
+        inset 0 1px 0 rgba(170, 210, 255, 0.25);
+    backdrop-filter: blur(10px);
+    z-index: 100020;
+}
+
+#countdownDisplay::before,
+.roll-cooldown-display::before {
+    content: "\f2f2";
+    font-family: "Font Awesome 6 Free";
+    font-weight: 900;
+    font-size: 16px;
+    color: #8eb8ff;
+}
+
+@media (max-width: 480px) {
+    #countdownDisplay,
+    .roll-cooldown-display {
+        right: 16px;
+        bottom: 92px;
+        padding: 10px 16px;
+        font-size: 14px;
+    }
 }
 
 #squareContainer {

--- a/index.html
+++ b/index.html
@@ -18,8 +18,12 @@
 <body>
   <div id="flashLayer" aria-hidden="true"></div>
 
-    <div class="version">
-        <a class="vNumber">Version: 1.2.5 <p class="vNumberDetailed">(1.2.5_upd)</p></a>
+    <div class="version" role="status" aria-live="polite">
+        <div class="vNumber">
+            <span class="vNumberLabel">Version</span>
+            <span class="vNumberValue">1.2.5</span>
+            <span class="vNumberDetailed">(1.2.5_upd)</span>
+        </div>
     </div>
 
     <canvas id="fireworksCanvas"></canvas>


### PR DESCRIPTION
## Summary
- move the roll display container to the bottom of the viewport with a narrower footprint to avoid menu overlaps
- refresh the version badge and cooldown overlay styling and positioning for better clarity
- extend the cutscene failsafe window to 40 seconds to keep longer sequences from being interrupted prematurely

## Testing
- manual verification in browser (see attached screenshot)


------
https://chatgpt.com/codex/tasks/task_e_68d9b63102b08321a5658bd45f56b138