### PR TITLE
Center roll panel and add cooldown progress indicator

### DIFF
--- a/files/style.css
+++ b/files/style.css
@@ -619,7 +619,10 @@ body.equinox-pulse-active :is(
         font-size: 16px;
     }
     .container {
-        width: 90%;
+        width: min(92vw, 520px);
+        bottom: 28px;
+        margin-left: 0;
+        transform: translateX(-50%);
     }
     #rollingHistory {
         visibility: hidden;
@@ -631,7 +634,10 @@ body.equinox-pulse-active :is(
         font-size: 14px;
     }
     .container {
-        width: 100%;
+        width: min(94vw, 460px);
+        bottom: 24px;
+        margin-left: 0;
+        transform: translateX(-50%);
     }
     #rollingHistory {
         visibility: hidden;
@@ -639,31 +645,60 @@ body.equinox-pulse-active :is(
     .container1 {
         left: 10px;
     }
+    .version {
+        top: 12px;
+    }
 }
 
 .version {
     color: #fff;
-    position: absolute;
-    bottom: 25px;
-    width: 100%;
-    z-index: 9;
+    position: fixed;
+    top: 20px;
+    left: 50%;
+    transform: translateX(-50%);
+    display: flex;
+    justify-content: center;
+    width: auto;
+    z-index: 100010;
+    pointer-events: none;
 }
 
 .vNumber {
-    font-weight: bold;
-    font-size: large;
-    left: 50%;
-    z-index: 9999999;
-    width: 300px;
-    padding: 20px;
-    background-color: #00000069;
-    border-radius: 25px;
+    display: inline-flex;
+    align-items: baseline;
+    gap: 10px;
+    padding: 10px 18px;
+    font-weight: 600;
+    font-size: 15px;
+    letter-spacing: 0.08em;
+    text-transform: uppercase;
+    color: #f9f9f9;
+    background:
+        linear-gradient(180deg, rgba(40, 40, 40, 0.75), rgba(22, 22, 22, 0.85));
+    border: 1px solid rgba(255, 255, 255, 0.16);
+    border-radius: 999px;
+    box-shadow:
+        0 10px 24px rgba(0, 0, 0, 0.35),
+        inset 0 1px 0 rgba(255, 255, 255, 0.18);
+    backdrop-filter: blur(8px);
+}
+
+.vNumberLabel {
+    font-size: 12px;
+    color: rgba(255, 255, 255, 0.7);
+    letter-spacing: 0.14em;
+}
+
+.vNumberValue {
+    font-size: 18px;
+    font-weight: 700;
+    color: #ffffff;
 }
 
 .vNumberDetailed {
-    color: #999;
-    display: inline;
-    margin-left: 5px;
+    color: rgba(180, 200, 255, 0.8);
+    font-size: 14px;
+    letter-spacing: 0.05em;
 }
 
 .heart {
@@ -838,12 +873,15 @@ body {
 
 /* Replace the old .container block with this */
 .container {
-  position: relative;
-  margin: 25vh auto 0 auto;          /* keep your vertical offset, center horizontally */
-  display: inline-block;
-  padding: 18px 18px 22px;
-  width: min(92vw, 740px);
-  border-radius: 16px;
+  position: fixed;
+  left: 50%;
+  bottom: clamp(24px, 5vh, 48px);
+  transform: translateX(-50%);
+  margin: 0;
+  display: block;
+  padding: clamp(18px, 3.2vh, 26px) clamp(20px, 4vw, 30px) clamp(22px, 4vh, 32px);
+  width: clamp(320px, 40vw, 560px);
+  border-radius: 18px;
 
   /* Layered glass look with your background image subtly present */
   background:
@@ -863,7 +901,7 @@ body {
 
   overflow: hidden;
   isolation: isolate;                 /* ensures pseudo-elements stack within */
-  z-index: 9999;                      /* same z-index as your old */
+  z-index: 100000;                    /* keep above surrounding UI */
 }
 
 /* Subtle animated sheen across the panel */
@@ -909,89 +947,94 @@ body {
 .container .containerInside {
   position: relative;
   z-index: 1;                         /* above pseudo-elements */
-  display: flex;
-  flex-direction: column;
+  display: grid;
+  grid-template-columns: 1fr;
+  grid-template-rows: auto 1fr auto;
   align-items: center;
-  gap: 14px;
-  padding: 6px 8px 2px;
+  gap: clamp(16px, 3vh, 26px);
+  padding: clamp(4px, 1vh, 8px) 0 0;
 }
 
 /* Title: crisp and subtle */
 .container .gameTitle {
   margin: 0;
-  padding: 6px 10px;
-  border-radius: 10px;
+  padding: clamp(4px, 1vh, 8px) clamp(10px, 2.8vw, 16px);
+  border-radius: 12px;
   font-size: clamp(20px, 3.2vw, 28px);
   font-weight: 800;
   color: #ffffff;
   letter-spacing: 0.6px;
-
   background: linear-gradient(180deg, rgba(255,255,255,0.14), rgba(255,255,255,0.06));
   border: 1px solid rgba(255,255,255,0.10);
   box-shadow: inset 0 1px 0 rgba(255,255,255,0.08);
 }
 
-/* Roll button: bold, tactile, and glowing on hover */
-.container .rButton {
+/* Roll button: wide pill with progress indicator */
+#rollButton {
   position: relative;
-  display: inline-grid;
-  place-items: center;
-  width: clamp(72px, 10vw, 92px);
-  height: clamp(72px, 10vw, 92px);
-  border-radius: 50%;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 100%;
+  min-height: clamp(56px, 8vh, 68px);
+  padding: clamp(14px, 2.8vh, 18px) clamp(22px, 5vw, 32px);
   border: 0;
+  border-radius: 999px;
   cursor: pointer;
-
-  color: #fff;
-  background: radial-gradient(circle at 50% 30%, #7aa4ff 0%, #4169e1 60%, #2b4bb3 100%);
+  overflow: hidden;
+  background: linear-gradient(135deg, rgba(116,195,255,0.92), rgba(78,137,255,0.95));
+  color: #04121f;
+  font-size: clamp(20px, 2.4vw, 26px);
+  font-weight: 700;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
   box-shadow:
-    0 10px 24px rgba(65,105,225,0.45),
-    inset 0 2px 8px rgba(255,255,255,0.25);
+    0 18px 36px rgba(64,120,255,0.35),
+    inset 0 1px 0 rgba(255,255,255,0.45);
   transition:
     transform 180ms ease,
     box-shadow 220ms ease,
-    filter 220ms ease;
-  will-change: transform, box-shadow, filter;
+    filter 220ms ease,
+    background 220ms ease;
+}
+
+#rollButton .rollButton__label {
+  position: relative;
   z-index: 1;
 }
 
-.container .rButton:hover {
-  transform: translateY(-2px);
-  box-shadow:
-    0 14px 28px rgba(65,105,225,0.55),
-    inset 0 2px 8px rgba(255,255,255,0.28);
-  filter: saturate(1.1);
-}
-
-.container .rButton:active {
-  transform: translateY(0);
-}
-
-/* Rolling icon slightly larger by default */
-.container .rButton i#roll {
-  font-size: clamp(14px, 2.1vw, 18px);
-  transform: translateY(1px); /* tiny nudge for visual centering */
-}
-
-/* Sheen across the roll button on hover */
-.container .rButton::after {
-  content: "";
+#rollButton .rollButton-progress {
   position: absolute;
   inset: 0;
-  border-radius: 50%;
-  background:
-    radial-gradient(60% 60% at 50% 10%, rgba(255,255,255,0.22), transparent 60%),
-    linear-gradient(110deg, transparent 45%, rgba(255,255,255,0.35) 50%, transparent 55%);
-  mix-blend-mode: screen;
+  background: linear-gradient(90deg, rgba(255,255,255,0.22), rgba(255,255,255,0.08));
+  transform: translateX(-100%);
+  transition: transform 200ms linear;
   opacity: 0;
-  transform: translateX(-30%);
-  transition: opacity 180ms ease, transform 280ms ease;
   pointer-events: none;
 }
 
-.container .rButton:hover::after {
+#rollButton.is-cooling .rollButton-progress {
   opacity: 1;
-  transform: translateX(0%);
+}
+
+#rollButton:hover:not(:disabled) {
+  transform: translateY(-2px);
+  filter: saturate(1.08);
+  box-shadow:
+    0 22px 40px rgba(64,120,255,0.42),
+    inset 0 1px 0 rgba(255,255,255,0.48);
+}
+
+#rollButton:active:not(:disabled) {
+  transform: translateY(0);
+}
+
+#rollButton:disabled {
+  cursor: not-allowed;
+  filter: saturate(0.85);
+  box-shadow:
+    0 12px 26px rgba(20,36,72,0.35),
+    inset 0 1px 0 rgba(255,255,255,0.32);
 }
 
 /* Result display panel */
@@ -1732,12 +1775,6 @@ body {
     box-shadow: 0 0 0 4px rgba(128, 96, 186, 0.2);
 }
 
-#rollButton.disabled {
-    pointer-events: none;
-    opacity: 0.5;
-    cursor: not-allowed;
-}
-
 .statsBtns {
     width: 100%;
     display: inline-flex;
@@ -2188,33 +2225,7 @@ body {
     left: 33px;
 }
 
-#roll {
-    scale: 300%;
-}
-
-.rButton:hover {
-    background: #4169e1;
-    transform: scale(1.1);
-}
-
-.rButton:active {
-    background: #2e4a9c;
-}
-
-.rButton:disabled {
-    background-color: #3a465c;
-    cursor: not-allowed;
-    animation: rollSpin 0.5s ease;
-}
-
-@keyframes rollSpin {
-    0% {
-        transform: rotate(0deg);
-    }
-    100% {
-        transform: rotate(360deg);
-    }
-}
+/* Legacy roll button overrides removed in favour of pill design */
 
 #result {
     margin-top: 20px;
@@ -4151,14 +4162,47 @@ body.flashing {
     transform: scale(1.05);
 }
 
-#countdownDisplay {
-    background-color: rgba(0, 0, 0, 0.7);
-    color: white;
-    padding: 10px;
-    border-radius: 5px;
-    font-size: 14px;
-    z-index: 1000;
-    box-shadow: 0 2px 10px rgba(0, 0, 0, 0.5);
+#countdownDisplay,
+.roll-cooldown-display {
+    position: fixed;
+    right: 32px;
+    bottom: 32px;
+    display: inline-flex;
+    align-items: center;
+    gap: 10px;
+    padding: 12px 18px;
+    color: #f3f6ff;
+    font-size: 15px;
+    font-weight: 600;
+    letter-spacing: 0.05em;
+    background:
+        linear-gradient(180deg, rgba(26, 30, 40, 0.78), rgba(16, 18, 24, 0.88));
+    border: 1px solid rgba(118, 169, 255, 0.35);
+    border-radius: 14px;
+    box-shadow:
+        0 14px 30px rgba(0, 0, 0, 0.45),
+        inset 0 1px 0 rgba(170, 210, 255, 0.25);
+    backdrop-filter: blur(10px);
+    z-index: 100020;
+}
+
+#countdownDisplay::before,
+.roll-cooldown-display::before {
+    content: "\f2f2";
+    font-family: "Font Awesome 6 Free";
+    font-weight: 900;
+    font-size: 16px;
+    color: #8eb8ff;
+}
+
+@media (max-width: 480px) {
+    #countdownDisplay,
+    .roll-cooldown-display {
+        right: 16px;
+        bottom: 92px;
+        padding: 10px 16px;
+        font-size: 14px;
+    }
 }
 
 #squareContainer {

--- a/index.html
+++ b/index.html
@@ -18,8 +18,12 @@
 <body>
   <div id="flashLayer" aria-hidden="true"></div>
 
-    <div class="version">
-        <a class="vNumber">Version: 1.2.5 <p class="vNumberDetailed">(1.2.5_upd)</p></a>
+    <div class="version" role="status" aria-live="polite">
+        <div class="vNumber">
+            <span class="vNumberLabel">Version</span>
+            <span class="vNumberValue">1.2.5</span>
+            <span class="vNumberDetailed">(1.2.5_upd)</span>
+        </div>
     </div>
 
     <canvas id="fireworksCanvas"></canvas>
@@ -384,10 +388,12 @@
             <div class="containerInside">
                 <h1 class="gameTitle">Unnamed's RNG</h1>
 
-                <button class="rButton" id="rollButton" onclick="clickSound()"><i id="roll" class="fa-solid fa-arrows-rotate"></i></button>
-
-                
                 <div class="res" id="result"></div>
+
+                <button class="rButton" id="rollButton" type="button" onclick="clickSound()">
+                    <span class="rollButton__label">Roll</span>
+                    <span class="rollButton-progress" aria-hidden="true"></span>
+                </button>
             </div>
         </div>
 


### PR DESCRIPTION
## Summary
- center the roll display card between the surrounding panels and restyle the roll trigger as a full-width pill with built-in progress overlay
- add DOM observers that animate the pill's cooldown sweep using the measured disable duration, including cooldown buff support
- update the cooldown buff timing logic so the new animation stays in sync with reduced cooldown windows

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68d9b63102b08321a5658bd45f56b138