### PR TITLE
Center roll button and extend cutscene failsafe window

### DIFF
--- a/files/script.js
+++ b/files/script.js
@@ -82,7 +82,9 @@ let rollDisplayHiddenByUser = false;
 let cutsceneHidRollDisplay = false;
 let cutsceneActive = false;
 let cutsceneFailsafeTimeout = null;
-const CUTSCENE_FAILSAFE_DURATION_MS = 40000;
+// Keep the safeguard comfortably longer than any scripted cutscene
+// so extended sequences aren't aborted before their own cleanup runs.
+const CUTSCENE_FAILSAFE_DURATION_MS = 120000;
 let lastRollPersisted = true;
 let lastRollAutoDeleted = false;
 let lastRollRarityClass = null;

--- a/files/style.css
+++ b/files/style.css
@@ -949,6 +949,7 @@ body {
   grid-template-columns: 1fr;
   grid-template-rows: auto 1fr auto;
   align-items: center;
+  justify-items: center;
   gap: clamp(16px, 3vh, 26px);
   padding: clamp(4px, 1vh, 8px) 0 0;
 }
@@ -973,7 +974,8 @@ body {
   display: inline-flex;
   align-items: center;
   justify-content: center;
-  width: 100%;
+  justify-self: center;
+  width: min(100%, 360px);
   min-height: clamp(56px, 8vh, 68px);
   padding: clamp(14px, 2.8vh, 18px) clamp(22px, 5vw, 32px);
   border: 0;


### PR DESCRIPTION
## Summary
- center the roll button within its panel so it no longer hugs the left edge
- extend the cutscene failsafe window so lengthy cutscenes can complete before the safeguard triggers

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68dba24b1aac83218e618a29e5f233f3