### PR TITLE
Fix event achievement unlock logic and tooltip layout

### DIFF
--- a/files/script.js
+++ b/files/script.js
@@ -1672,8 +1672,8 @@ function checkAchievements(context = {}) {
     : new Set(storage.get("rolledRarityBuckets", []));
   const qualifyingInventoryCount = getQualifyingInventoryCount();
   const inventoryTitleSet = new Set();
-  const activeEventBucketCounts = new Map();
-  let totalActiveEventTitleCount = 0;
+  const eventBucketCounts = new Map();
+  let totalEventTitleCount = 0;
 
   if (Array.isArray(inventory)) {
     inventory.forEach((item) => {
@@ -1690,18 +1690,16 @@ function checkAchievements(context = {}) {
         normalizeRarityBucket(item.rarityClass);
 
       if (bucket && bucket.startsWith("event")) {
-        if (isEventBucketActive(bucket)) {
-          totalActiveEventTitleCount += 1;
-          activeEventBucketCounts.set(
-            bucket,
-            (activeEventBucketCounts.get(bucket) || 0) + 1
-          );
-        }
+        totalEventTitleCount += 1;
+        eventBucketCounts.set(
+          bucket,
+          (eventBucketCounts.get(bucket) || 0) + 1
+        );
       }
     });
   }
 
-  const distinctActiveEventBucketCount = activeEventBucketCounts.size;
+  const distinctEventBucketCount = eventBucketCounts.size;
 
   ACHIEVEMENTS.forEach((achievement) => {
     if (achievement.count && rollCount >= achievement.count) {
@@ -1750,7 +1748,7 @@ function checkAchievements(context = {}) {
 
     if (
       achievement.requiredEventBucket &&
-      activeEventBucketCounts.has(achievement.requiredEventBucket)
+      eventBucketCounts.has(achievement.requiredEventBucket)
     ) {
       unlockAchievement(achievement.name, unlocked);
     }
@@ -1758,7 +1756,7 @@ function checkAchievements(context = {}) {
     if (
       Array.isArray(achievement.requiredEventBuckets) &&
       achievement.requiredEventBuckets.every((bucket) =>
-        activeEventBucketCounts.has(bucket)
+        eventBucketCounts.has(bucket)
       )
     ) {
       unlockAchievement(achievement.name, unlocked);
@@ -1766,14 +1764,14 @@ function checkAchievements(context = {}) {
 
     if (
       typeof achievement.minDistinctEventBuckets === "number" &&
-      distinctActiveEventBucketCount >= achievement.minDistinctEventBuckets
+      distinctEventBucketCount >= achievement.minDistinctEventBuckets
     ) {
       unlockAchievement(achievement.name, unlocked);
     }
 
     if (
       typeof achievement.minEventTitleCount === "number" &&
-      totalActiveEventTitleCount >= achievement.minEventTitleCount
+      totalEventTitleCount >= achievement.minEventTitleCount
     ) {
       unlockAchievement(achievement.name, unlocked);
     }

--- a/files/style.css
+++ b/files/style.css
@@ -4830,12 +4830,13 @@ body.flashing {
 
 .achievement-itemEvent[data-availability="inactive"] {
     cursor: not-allowed;
+    padding-top: 32px;
 }
 
 .achievement-itemEvent[data-availability="inactive"]::before {
     content: "Out of Season";
     position: absolute;
-    top: 10px;
+    top: 8px;
     right: 12px;
     font-size: 0.65rem;
     font-weight: 700;
@@ -4845,6 +4846,7 @@ body.flashing {
     padding: 2px 10px;
     border-radius: 999px;
     letter-spacing: 0.02em;
+    pointer-events: none;
 }
 
 .achievement-itemEvent[data-availability="inactive"]:hover {
@@ -4936,6 +4938,17 @@ body.flashing {
     font-size: 0.78rem;
     box-shadow: 0 16px 32px rgba(0, 0, 0, 0.35);
     z-index: 5;
+}
+
+.achievement-itemEvent:hover::after {
+    white-space: normal;
+    max-width: min(240px, calc(100vw - 48px));
+    text-align: center;
+}
+
+.achievement-itemEvent[data-event=""]::after,
+.achievement-itemEvent[data-event=""]::before {
+    content: none;
 }
 
 .achievement-item:hover::before,


### PR DESCRIPTION
## Summary
- count owned event titles for seasonal achievement checks so summer achievements unlock correctly
- adjust event badge padding and tooltip styling to avoid overlapping "Out of Season" labels and empty hover bars

## Testing
- not run (not available)


------
https://chatgpt.com/codex/tasks/task_e_68dbaa2120ac8321a2ec82c6a04fce0d