### PR TITLE
Add audio category sliders and auto-unequip deleted auras

### DIFF
--- a/index.html
+++ b/index.html
@@ -59,6 +59,33 @@
                                 <button id="muteButton" class="settings-btn settings-btn--ghost" type="button">Mute</button>
                             </div>
                         </div>
+                        <div class="settings-audio">
+                            <label class="settings-audio__label" for="rollAudioSlider">Rolling Sound Volume</label>
+                            <div class="settings-audio__controls">
+                                <div class="settings-audio__slider">
+                                    <input type="range" id="rollAudioSlider" min="0" max="1" step="0.01" value="1">
+                                    <span id="rollAudioSliderValue" class="settings-audio__value">100%</span>
+                                </div>
+                            </div>
+                        </div>
+                        <div class="settings-audio">
+                            <label class="settings-audio__label" for="titleAudioSlider">Title Music Volume</label>
+                            <div class="settings-audio__controls">
+                                <div class="settings-audio__slider">
+                                    <input type="range" id="titleAudioSlider" min="0" max="1" step="0.01" value="1">
+                                    <span id="titleAudioSliderValue" class="settings-audio__value">100%</span>
+                                </div>
+                            </div>
+                        </div>
+                        <div class="settings-audio">
+                            <label class="settings-audio__label" for="menuAudioSlider">Main Menu Music Volume</label>
+                            <div class="settings-audio__controls">
+                                <div class="settings-audio__slider">
+                                    <input type="range" id="menuAudioSlider" min="0" max="1" step="0.01" value="1">
+                                    <span id="menuAudioSliderValue" class="settings-audio__value">100%</span>
+                                </div>
+                            </div>
+                        </div>
                     </section>
 
                     <section class="settings-section">


### PR DESCRIPTION
## Summary
- add dedicated volume sliders for rolling sound effects, title music, and main menu music with persistent settings
- load saved audio balances at startup and apply category-aware volume control across all audio playback
- automatically unequip titles when their inventory entry is deleted to keep equipped state consistent

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68dbace125c0832195063a160b4c7fbe