### PR TITLE
Add cutscene audio controls and safeguard inventory actions

### DIFF
--- a/index.html
+++ b/index.html
@@ -69,6 +69,15 @@
                             </div>
                         </div>
                         <div class="settings-audio">
+                            <label class="settings-audio__label" for="cutsceneAudioSlider">Cutscene Music Volume</label>
+                            <div class="settings-audio__controls">
+                                <div class="settings-audio__slider">
+                                    <input type="range" id="cutsceneAudioSlider" min="0" max="1" step="0.01" value="1">
+                                    <span id="cutsceneAudioSliderValue" class="settings-audio__value">100%</span>
+                                </div>
+                            </div>
+                        </div>
+                        <div class="settings-audio">
                             <label class="settings-audio__label" for="titleAudioSlider">Title Music Volume</label>
                             <div class="settings-audio__controls">
                                 <div class="settings-audio__slider">


### PR DESCRIPTION
## Summary
- add a dedicated cutscene volume slider and persist its state alongside existing audio controls
- delay cutscene music playback by 100ms and respect the new volume category during runtime
- disable inventory aura deletion buttons while cutscenes are active to prevent mid-scene changes

## Testing
- No automated tests were run (not available)

------
https://chatgpt.com/codex/tasks/task_e_68dbc2f653cc8321870d89902e3a5c97