### PR TITLE
Keep profile dropdown open until outside click

### DIFF
--- a/files/script.js
+++ b/files/script.js
@@ -11552,6 +11552,10 @@ function openProfileDropdown() {
   }
 
   profileDropdownOutsideHandler = (event) => {
+    if (!event.isTrusted) {
+      return;
+    }
+
     if (!dropdown.contains(event.target) && !trigger.contains(event.target)) {
       closeProfileDropdown();
     }
@@ -11592,19 +11596,11 @@ function closeProfileDropdown() {
 
 function openDiscord() {
   window.open("https://discord.gg/m6k7Jagm3v", "_blank");
-  closeProfileDropdown();
 }
 
 function openGithub() {
   window.open("https://github.com/The-Unnamed-Official/Unnamed-RNG/tree/published", "_blank");
-  closeProfileDropdown();
 }
-
-document.addEventListener("keydown", (event) => {
-  if (event.key === "Escape") {
-    closeProfileDropdown();
-  }
-});
 
 function selectTitle(rarity) {
   const titles = rarity.titles;


### PR DESCRIPTION
## Summary
- keep the profile dropdown open after interacting with its actions by removing the forced close calls
- eliminate the escape-key shortcut so the dropdown only dismisses on outside clicks
- prevent auto-roll's synthetic clicks from closing the profile dropdown by ignoring untrusted click events

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68dbfbe683508321b610adce951031b1