### PR TITLE
Fix cutscene skip toggle display

### DIFF
--- a/files/script.js
+++ b/files/script.js
@@ -950,7 +950,12 @@ const CUTSCENE_STATE_GETTERS = {
   skipCutsceneTranscendent: () => skipCutsceneTranscendent,
 };
 
-function updateCutsceneSkipDisplay({ labelId, label, buttonId }, isSkipping) {
+function updateCutsceneSkipDisplay(
+  { labelId, label, buttonId },
+  cutsceneEnabled
+) {
+  const isSkipping = !cutsceneEnabled;
+
   const labelElement = byId(labelId);
   if (labelElement) {
     labelElement.textContent = `${label} ${isSkipping ? "On" : "Off"}`;
@@ -958,7 +963,7 @@ function updateCutsceneSkipDisplay({ labelId, label, buttonId }, isSkipping) {
 
   const buttonElement = byId(buttonId);
   if (buttonElement) {
-    buttonElement.classList.toggle("active", Boolean(isSkipping));
+    buttonElement.classList.toggle("active", isSkipping);
   }
 }
 
@@ -10847,7 +10852,10 @@ function registerCutsceneToggleButtons() {
       const nextValue = !Boolean(readState());
       assignState(nextValue);
       storage.set(key, nextValue);
-      console.log(`Cutscene skip for ${config.label} has been set to ${nextValue}`);
+      const isSkipping = !nextValue;
+      console.log(
+        `Cutscene skip for ${config.label} is now ${isSkipping ? "On" : "Off"}`
+      );
       updateCutsceneSkipDisplay(config, nextValue);
     });
   });


### PR DESCRIPTION
## Summary
- invert the cutscene skip toggle display so it shows On when skipping cutscenes
- ensure the toggle button styling and console log match the actual skip state

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68dc00fda8ec83219c42296877ac32f3