### PR TITLE
Fix event achievement availability and tooltip formatting

### DIFF
--- a/files/style.css
+++ b/files/style.css
@@ -5143,8 +5143,10 @@ body.flashing {
 }
 
 .achievement-itemEvent:hover::after {
+    display: block;
     white-space: normal;
-    max-width: min(320px, calc(100vw - 48px));
+    width: max-content;
+    max-width: min(360px, calc(100vw - 48px));
     text-align: center;
 }
 

--- a/index.html
+++ b/index.html
@@ -299,45 +299,99 @@
                     <div class="achievements-subsection">
                         <h5 class="achievements-section__subtitle">Spring &amp; Easter</h5>
                         <div class="achievement-grid">
-                            <div class="achievement-itemE achievement-itemEvent" data-event="Obtain an Easter event title to unlock this achievement" data-name="Happy Easter!">Happy Easter!</div>
+                            <div
+                                class="achievement-itemE achievement-itemEvent"
+                                data-event="Obtain an Easter event title to unlock this achievement"
+                                data-name="Happy Easter!"
+                            >
+                                Happy Easter!
+                            </div>
                         </div>
                     </div>
                     <div class="achievements-subsection">
                         <h5 class="achievements-section__subtitle">Summer</h5>
                         <div class="achievement-grid">
-                            <div class="achievement-itemSum achievement-itemEvent" data-event="Obtain a Summer event title to unlock this achievement" data-name="Happy Summer!">Happy Summer!</div>
+                            <div
+                                class="achievement-itemSum achievement-itemEvent"
+                                data-event="Obtain a Summer event title to unlock this achievement"
+                                data-name="Happy Summer!"
+                            >
+                                Happy Summer!
+                            </div>
                         </div>
                     </div>
                     <div class="achievements-subsection">
                         <h5 class="achievements-section__subtitle">Valentine's</h5>
                         <div class="achievement-grid">
-                            <div class="achievement-itemEvent" data-event="Share the love with a Valentine's event title to unlock this achievement" data-name="Valentine's Sweetheart">Valentine's Sweetheart</div>
+                            <div
+                                class="achievement-itemEvent"
+                                data-event="Share the love with a Valentine's event title to unlock this achievement"
+                                data-name="Valentine's Sweetheart"
+                            >
+                                Valentine's Sweetheart
+                            </div>
                         </div>
                     </div>
                     <div class="achievements-subsection">
                         <h5 class="achievements-section__subtitle">Festival of Fire</h5>
                         <div class="achievement-grid">
-                            <div class="achievement-itemEvent" data-event="Secure the Firecracker festival title to unlock this achievement" data-name="Festival Firecracker">Festival Firecracker</div>
+                            <div
+                                class="achievement-itemEvent"
+                                data-event="Secure the Firecracker festival title to unlock this achievement"
+                                data-name="Festival Firecracker"
+                            >
+                                Festival Firecracker
+                            </div>
                         </div>
                     </div>
                     <div class="achievements-subsection">
                         <h5 class="achievements-section__subtitle">Halloween</h5>
                         <div class="achievement-grid">
-                            <div class="achievement-itemEvent" data-event="Collect a Halloween-exclusive title to unlock this achievement" data-name="Spooky Spectator">Spooky Spectator</div>
+                            <div
+                                class="achievement-itemEvent"
+                                data-event="Collect a Halloween-exclusive title to unlock this achievement"
+                                data-name="Spooky Spectator"
+                            >
+                                Spooky Spectator
+                            </div>
                         </div>
                     </div>
                     <div class="achievements-subsection">
                         <h5 class="achievements-section__subtitle">Winter Holidays</h5>
                         <div class="achievement-grid">
-                            <div class="achievement-itemEvent" data-event="Gather a Winter holiday title to unlock this achievement" data-name="Winter Wonderland">Winter Wonderland</div>
+                            <div
+                                class="achievement-itemEvent"
+                                data-event="Gather a Winter holiday title to unlock this achievement"
+                                data-name="Winter Wonderland"
+                            >
+                                Winter Wonderland
+                            </div>
                         </div>
                     </div>
                     <div class="achievements-subsection">
                         <h5 class="achievements-section__subtitle">Seasonal Collections</h5>
                         <div class="achievement-grid">
-                            <div class="achievement-itemEvent" data-event="Obtain any event title to unlock this achievement" data-name="Seasonal Tourist">Seasonal Tourist</div>
-                            <div class="achievement-itemEvent" data-event="Hold titles from three different events to unlock this achievement" data-name="Event Explorer">Event Explorer</div>
-                            <div class="achievement-itemEvent" data-event="Store 10 event titles across your vault to unlock this achievement" data-name="Seasonal Archivist">Seasonal Archivist</div>
+                            <div
+                                class="achievement-itemEvent"
+                                data-event="Obtain any event title to unlock this achievement"
+                                data-name="Seasonal Tourist"
+                            >
+                                Seasonal Tourist
+                            </div>
+                            <div
+                                class="achievement-itemEvent"
+                                data-event="Hold titles from three different events to unlock this achievement"
+                                data-name="Event Explorer"
+                            >
+                                Event Explorer
+                            </div>
+                            <div
+                                class="achievement-itemEvent"
+                                data-event="Store 10 event titles across your vault to unlock this achievement"
+                                data-name="Seasonal Archivist"
+                            >
+                                Seasonal Archivist
+                            </div>
                         </div>
                     </div>
                 </section>


### PR DESCRIPTION
## Summary
- ensure transcendent and seasonal titles contribute to vault and seasonal achievement tracking
- flag seasonal achievements as available whenever players have progress and remove stale unavailable messaging
- clean up event achievement tooltip markup and widen the hover tooltip for better readability

## Testing
- No automated tests were run (not provided)


------
https://chatgpt.com/codex/tasks/task_e_68dc0412f5cc8321bc438355857f53b8