### PR TITLE
Add reduced animation toggle in settings menu

### DIFF
--- a/files/style.css
+++ b/files/style.css
@@ -28,6 +28,41 @@
   }
 }
 
+body.reduced-motion {
+  --btn-transition: 0ms linear;
+}
+
+body.reduced-motion *,
+body.reduced-motion *::before,
+body.reduced-motion *::after {
+  animation-duration: 0.001ms !important;
+  animation-iteration-count: 1 !important;
+  animation-delay: 0ms !important;
+  transition-duration: 0.001ms !important;
+  transition-delay: 0ms !important;
+  scroll-behavior: auto !important;
+}
+
+body.reduced-motion #fireworksCanvas,
+body.reduced-motion .loading-animation,
+body.reduced-motion .particle-system {
+  display: none !important;
+}
+
+body.reduced-motion.equinox-pulse-active {
+  animation: none !important;
+}
+
+body.reduced-motion.equinox-pulse-active::before,
+body.reduced-motion.equinox-pulse-active::after {
+  animation: none !important;
+  content: none;
+}
+
+body.reduced-motion .rollButton-progress {
+  transition: none !important;
+}
+
 /* Base button apply: native buttons and common classes */
 button,
 input[type="button"],

--- a/index.html
+++ b/index.html
@@ -103,6 +103,7 @@
                         <div class="settings-grid">
                             <button id="toggleRollDisplayBtn" class="settings-btn settings-btn--ghost" type="button">Hide Roll &amp; Display</button>
                             <button id="toggleRollHistoryBtn" class="settings-btn settings-btn--ghost" type="button">Hide Roll History</button>
+                            <button id="toggleReducedAnimationsBtn" class="settings-btn settings-btn--ghost" type="button">Reduce Animations</button>
                         </div>
                     </section>
 


### PR DESCRIPTION
## Summary
- add a reduced animations control to the settings interface
- persist the preference in local storage while disabling screen shake, equinox pulses, roll cooldown animations, and fireworks when enabled
- apply a reduced-motion stylesheet override to remove transitions and hide animation-heavy layers

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68e5a229a2d883219ec769ac56cfe59e